### PR TITLE
Feature: Grouping Queries

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-'npx lint-staged'  
+npx lint-staged 

--- a/.prettierignore
+++ b/.prettierignore
@@ -4,3 +4,11 @@
 coverage
 dist
 node_modules
+.lintstagedrc
+.prettierrc
+.stylelintrc
+package-lock.json
+package.json
+*.md
+tsc.config.json
+*.html

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,13 +1,13 @@
 body {
     background-color: #222;
     color: #fff;
-    margin: 0;
     font-family: Arial, sans-serif;
+    margin: 0;
 }
 
 .content-wrapper {
-    height: 100vh;
     align-items: center;
+    height: 100vh;
 }
 
 .row {
@@ -19,9 +19,9 @@ body {
 
 .column {
     display: flex;
-    flex-direction: column;
-    flex-basis: 100%;
     flex: 1;
+    flex-basis: 100%;
+    flex-direction: column;
 }
 
 .align-center {

--- a/dts-bundle-generator.config.ts
+++ b/dts-bundle-generator.config.ts
@@ -1,11 +1,11 @@
 const config = {
-  entries: [
-    {
-      filePath: "./src/index.ts",
-      outFile: "./build/dist/index.d.ts",
-      noCheck: false,
-    },
-  ],
+    entries: [
+        {
+            filePath: './src/index.ts',
+            outFile: './build/dist/index.d.ts',
+            noCheck: false,
+        },
+    ],
 };
 
 module.exports = config;

--- a/index.html
+++ b/index.html
@@ -1,13 +1,29 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Jelly SQL</title>
-  </head>
-  <body>
-    <div id="app"></div>
-    <script type="module" src="/src/index.ts"></script>
-  </body>
+    <head>
+        <meta charset="UTF-8" />
+        <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Jelly SQL</title>
+    </head>
+
+    <body>
+        <div id="app">
+            <!-- Test Compound Expression Selectors (Basic) -->
+            <div hidden>
+                <a href="https:\\www.jellysql.com" target="_blank"> HREF Only </a>
+
+                <a href="https:\\www.jellysql.com" onclick="someFunc('https:\\www.jellysql.com')"> HREF and OnClick </a>
+
+                <a onclick="someFunc('https:\\www.jellysql.com')"> OnClick Only </a>
+
+                <button href="https:\\www.jellysql.com" target="_blank">HREF Only</button>
+
+                <button href="https:\\www.jellysql.com" onclick="someFunc('https:\\www.jellysql.com')">HREF and OnClick</button>
+
+                <button onclick="someFunc('https:\\www.jellysql.com')">OnClick Only</button>
+            </div>
+        </div>
+        <script type="module" src="/src/index.ts"></script>
+    </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import "./style.css";
+import './style.css';
 
 export * from './localTesting';

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -1,4 +1,4 @@
-import { FunctionType, KeywordType, OperatorType, SymbolType, TokenType } from "./types";
+import { FunctionType, KeywordType, OperatorType, SymbolType, TokenType } from './types';
 
 /** ------ Lookup Lists ------ */
 

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -1,5 +1,5 @@
-import { functions, keywords, operators, Regex } from "./constants";
-import { Token, TokenType } from "./types";
+import { functions, keywords, operators, Regex } from './constants';
+import { Token, TokenType } from './types';
 
 function cleanToken(value: string): string {
     if (value.startsWith("'")) value = value.substring(1);
@@ -84,10 +84,10 @@ function lexer(input: string): Token[] {
                     Value: functionName,
                     Arguments: tokenizeArguments($function),
                 });
-            }
 
-            seekPosition += matchValue.length;
-            continue;
+                seekPosition += matchValue.length;
+                continue;
+            }
         }
 
         /* ------ Operators ------ */

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -38,7 +38,7 @@ enum OperatorType {
 
 enum FunctionType {
     ATTRIBUTE = 'ATTRIBUTE',
-    TAG = 'TAG'
+    TAG = 'TAG',
 }
 
 enum CompoundType {

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -1,5 +1,5 @@
 import { lexer } from './lexer';
-import { buildExpressions } from './parser/expressionBuilder';
+import { parser } from './parser';
 
 /** Html element selectors
  *
@@ -162,14 +162,12 @@ const sqlDomQuery = `SELECT * FROM Dom WHERE
 const lexerTokens = lexer(sqlDomQuery);
 console.log(lexerTokens);
 
-const queryTokens = buildExpressions(lexerTokens);
-console.log('Query Tokens: ', queryTokens);
-
-// const querySelector = parser(lexerTokens);
-// console.log(querySelector);
+const querySelector = parser(lexerTokens);
+console.log(querySelector);
 
 //manualQuerySelectorChecks();
 
+// @ts-ignore
 function manualQuerySelectorChecks() {
     const querySelectors = [
         'a[href*="jellysql.com"], a[onclick*="jellysql.com"]',

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -1,8 +1,8 @@
-import { lexer } from "./lexer";
-import { parser } from "./parser";
+import { lexer } from './lexer';
+import { buildExpressions } from './parser/expressionBuilder';
 
 /** Html element selectors
- * 
+ *
  * - Tag
  * - Id
  * - Attribute
@@ -11,9 +11,9 @@ import { parser } from "./parser";
  */
 
 /**HTML Elements
- * 
+ *
  *  a, abbr, acronym (Deprecated), address, area, article, aside, audio, b, base, bdi, bdo, big (Deprecated), blockquote, body, br, button, canvas, caption, center (Deprecated), cite, code, col, colgroup, data, datalist, dd, del, details, dfn, dialog, dir (Deprecated), div, dl, dt, em, embed, fencedframe (Experimental), fieldset, figcaption, figure, font (Deprecated), footer, form, frame (Deprecated), frameset (Deprecated), h1, head, header, hgroup, hr, html, i, iframe, img, input, ins, kbd, label, legend, li, link, main, map, mark, marquee (Deprecated), menu, meta, meter, nav, nobr (Deprecated), noembed (Deprecated), noframes (Deprecated), noscript, object, ol, optgroup, option, output, p, param (Deprecated), picture, plaintext (Deprecated), portal (Experimental), pre, progress, q, rb (Deprecated), rp, rt, rtc (Deprecated), ruby, s, samp, script, search, section, select, slot, small, source, span, strike (Deprecated), strong, style, sub, summary, sup, table, tbody, td, template, textarea, tfoot, th, thead, time, title, tr, track, tt (Deprecated), u, ul, var, video, wbr, xmp
- * 
+ *
  * - a
  * - abbr
  * - acronym (Deprecated)
@@ -143,7 +143,8 @@ import { parser } from "./parser";
  * - xmp
  */
 
-  const sqlDomQuery = `SELECT * FROM Dom WHERE
+/**
+ * SELECT * FROM Dom WHERE
     Id LIKE 'btn'
     AND Id NOT LIKE 'btn-confirm' OR Id = 'a-confirm'
     AND Id <> 'modal-delete-user'
@@ -151,10 +152,35 @@ import { parser } from "./parser";
     AND Class LIKE '-primary'
     AND Class CONTAINS 'btn-primary' OR Class NOT CONTAINS 'btn-small'
     AND Attribute('data-color') = 'red'
-  `;
+ */
 
-  const lexerTokens = lexer(sqlDomQuery);  
-  console.log(lexerTokens);
+const sqlDomQuery = `SELECT * FROM Dom WHERE
+  Tag = 'a'
+  AND (Attribute('href') LIKE 'jellysql.com' OR Attribute('onclick') LIKE 'jellysql.com')
+`;
 
-  const querySelector = parser(lexerTokens);
-  console.log(querySelector);
+const lexerTokens = lexer(sqlDomQuery);
+console.log(lexerTokens);
+
+const queryTokens = buildExpressions(lexerTokens);
+console.log('Query Tokens: ', queryTokens);
+
+// const querySelector = parser(lexerTokens);
+// console.log(querySelector);
+
+//manualQuerySelectorChecks();
+
+function manualQuerySelectorChecks() {
+    const querySelectors = [
+        'a[href*="jellysql.com"], a[onclick*="jellysql.com"]',
+        'a[href*="jellysql.com"][onclick*="jellysql.com"]',
+        'a[href*="jellysql.com"][onclick*="jellysql.com"], button[href*="jellysql.com"][onclick*="jellysql.com"]',
+        'a[href*="jellysql.com"] a[onclick*="jellysql.com"]',
+    ];
+
+    for (let i = 0; i < querySelectors.length; i++) {
+        const jsElements = document.querySelectorAll(querySelectors[i]);
+
+        console.log(`${querySelectors[i]}: `, jsElements);
+    }
+}

--- a/src/parser/expressionBuilder.ts
+++ b/src/parser/expressionBuilder.ts
@@ -1,0 +1,121 @@
+import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer/types';
+
+import { CompoundExpression, Expression, QueryToken } from './types';
+
+let _tokens: Token[] = [];
+
+/**
+ * Parses an array of tokens and constructs an array of query tokens.
+ *
+ * This function processes a list of tokens to build expressions and compound
+ * expressions based on logical operators and symbols (e.g., parentheses).
+ * It identifies sections of the token list that represent WHERE clauses and
+ * organizes the tokens into structured query tokens.
+ *
+ * @param tokens - The array of tokens to be processed.
+ * @returns An array of query tokens representing the parsed expressions.
+ */
+function buildExpressions(tokens: Token[]): QueryToken[] {
+    _tokens = [...tokens];
+
+    let cutIdx = _tokens.findIndex(x => x.Type === TokenType.KEYWORD && x.Value === KeywordType.WHERE);
+
+    if (cutIdx + 1 < _tokens.length) return [];
+
+    _tokens = _tokens.slice(cutIdx + 1);
+
+    let hasFirstQueryBeenConsumed = false;
+    let compoundExpression: CompoundExpression | null = null;
+    let expression: Expression | null = null;
+    let queryTokens: QueryToken[] = [];
+
+    while (_tokens.length > 0) {
+        let operator: Token | null = null;
+        const currentQueryTokenCount = queryTokens.length;
+
+        if (hasFirstQueryBeenConsumed) {
+            let _token = _tokens.shift();
+
+            if (_token) operator = _token;
+        } else {
+            operator = { Type: TokenType.OPERATOR, Value: OperatorType.AND };
+            hasFirstQueryBeenConsumed = true;
+        }
+
+        while (queryTokens.length == currentQueryTokenCount && _tokens.length > 0) {
+            let token = _tokens.shift();
+
+            if (!token) continue;
+
+            if (token.Type === TokenType.SYMBOL) {
+                if (token.Value == SymbolType.LPAREN && compoundExpression == null) {
+                    compoundExpression = {
+                        Expressions: [],
+                        JoiningOperator: (operator?.Value as OperatorType.AND | OperatorType.OR) ?? OperatorType.AND,
+                    };
+                } else if (token.Value === SymbolType.RPAREN && compoundExpression && expression) {
+                    compoundExpression.Expressions.push(expression);
+                    queryTokens.push({ CompoundExpression: compoundExpression });
+
+                    expression = null;
+                    compoundExpression = null;
+                }
+            } else if (token?.Value == OperatorType.AND || token?.Value == OperatorType.OR) {
+                if (expression) {
+                    if (compoundExpression) {
+                        compoundExpression.Expressions.push(expression);
+
+                        expression = {
+                            Tokens: [],
+                            JoiningOperator: (token?.Value as OperatorType.AND | OperatorType.OR) ?? OperatorType.AND,
+                        };
+                    } else {
+                        queryTokens.push({
+                            Expression: expression,
+                        });
+
+                        expression = null;
+                        _tokens.unshift(token);
+                    }
+                } else {
+                    _tokens.unshift(token);
+                }
+            } else if (expression) {
+                expression.Tokens.push(token);
+            } else {
+                expression = {
+                    Tokens: [token],
+                    JoiningOperator: (operator?.Value as OperatorType.AND | OperatorType.OR) ?? OperatorType.AND,
+                };
+            }
+        }
+
+        if (expression) {
+            const queryTokensCnt = queryTokens.length;
+            const previousQueryToken = queryTokensCnt > 0 ? queryTokens[queryTokensCnt - 1] : null;
+
+            /* When a `OR` is next to a `AND`, make the two a compound */
+            if (previousQueryToken?.Expression?.JoiningOperator == OperatorType.AND && expression.JoiningOperator == OperatorType.OR) {
+                // Previous wasn't a compoundQuery && remainder of `if` statement is true
+                queryTokens.pop();
+
+                queryTokens.push({
+                    CompoundExpression: {
+                        JoiningOperator: OperatorType.AND,
+                        Expressions: [previousQueryToken.Expression, expression],
+                    },
+                });
+            } else {
+                queryTokens.push({
+                    Expression: expression,
+                });
+            }
+
+            expression = null;
+        }
+    }
+
+    return queryTokens;
+}
+
+export { buildExpressions };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,222 +1,218 @@
-import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer/types';
+import { KeywordType, OperatorType, Token, TokenType } from '@/lexer/types';
 
-import { OperationType, QueryToken } from './types';
+import { buildExpressions } from './expressionBuilder';
+import { Expression, OperationType, QueryToken, Selector, SelectorGroup } from './types';
+import { getAttributeName, getSimpleOperationType } from './utilities';
+import { hasSecondaryOperator } from './validators';
 
-let _tokens: Token[] = [];
-let _queryTokens: QueryToken[] = [];
-let _consumedTokens: Token[] = [];
-let _queries: string[] = [];
-//let _secondaryParsingTokens: Token[];
+/**
+ * Processes a single QueryToken to create selector groups.
+ * A selector group represents a logical grouping of selectors based on their joining operators.
+ * Selectors joined by the AND operator are grouped together, while selectors with other operators (like OR) are separated into their own groups.
+ *
+ * @param queryToken - The QueryToken object containing an array of expressions and the joining operator between them.
+ * @returns An array of SelectorGroup objects, each representing a logical group of selectors.
+ */
+function createSelectors(queryToken: QueryToken): SelectorGroup[] {
+    let selectors: Selector[] = [];
+    let groupings: SelectorGroup[] = [];
 
-const nextToken = () => (_tokens.length > 1 ? _tokens[0] : null);
+    for (let i = 0; i < queryToken.Expressions.length; i++) {
+        const selector = createSelector(queryToken.Expressions[i]);
 
-function consumeToken(tokenType: TokenType, alternateTypes: TokenType[] | null = null): Token {
-    const token = _tokens.shift();
-
-    if (!token) {
-        throw new Error(`Invalid Type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but found no tokens in sequence.`);
-    } else if (token?.Type != tokenType && !alternateTypes?.includes(token?.Type)) {
-        if ((alternateTypes?.length ?? 0) > 0) {
-            throw new Error(`Invalid type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but got ${token?.Type} with value ${token?.Value}`);
+        if (selector.JoiningOperator === OperatorType.AND) {
+            selectors.push(selector);
         } else {
-            throw new Error(`Invalid type. Expected ${tokenType}, but got ${token?.Type} with value ${token?.Value}`);
+            groupings.push({ Selectors: [selector] });
         }
     }
 
-    _consumedTokens.push(token);
-
-    return token;
-}
-
-function getSimpleOperationType(value: string, secondaryValue: string | null): OperationType {
-    if (value === SymbolType.ASSIGN || value === OperatorType.EQUALS || value === SymbolType.EQ) {
-        return OperationType.EQUALS;
-    } else if (value === SymbolType.NEQ || value === SymbolType.NEQ_LG || (value === OperatorType.NOT && secondaryValue === OperatorType.EQUALS)) {
-        return OperationType.NOT_EQUALS;
-    } else if (value === OperatorType.LIKE) {
-        return OperationType.LIKE;
-    } else if (value === OperatorType.NOT && secondaryValue === OperatorType.LIKE) {
-        return OperationType.NOT_LIKE;
-    } else if (value === OperatorType.CONTAINS) {
-        return OperationType.CONTAINS;
-    } else if (value === OperatorType.NOT && secondaryValue === OperationType.CONTAINS) {
-        return OperationType.NOT_CONTAINS;
+    if (selectors.length > 0) {
+        groupings.unshift({ Selectors: selectors });
     }
 
-    return OperationType.UNKNOWN;
+    return groupings;
 }
 
-function hasSecondaryOperator(operator: Token, nextToken: Token | null): Boolean {
-    if (nextToken == null) return false;
+/**
+ * Groups selectors from multiple QueryTokens into a combined set of selector groups.
+ * This function manages the merging of selectors based on their joining operators,
+ * combining those joined by AND and separating those with other operators.
+ *
+ * @param queryTokens - An array of QueryToken objects, each containing expressions and operators.
+ * @returns An array of SelectorGroup objects, where each group represents a logical combination of selectors.
+ */
+function groupSelectors(queryTokens: QueryToken[]): SelectorGroup[] {
+    let groupings: SelectorGroup[] = [];
 
-    if (operator.Value === OperatorType.NOT) {
-        switch (nextToken.Value) {
-            case OperatorType.EQUALS:
-                return true;
-            case OperatorType.LIKE:
-                return true;
-            case OperatorType.CONTAINS:
-                return true;
+    for (let i = 0; i < queryTokens.length; i++) {
+        const queryGroupings = createSelectors(queryTokens[i]);
+        const lastGrouping = queryTokens[i].JoiningOperator === OperatorType.AND ? groupings.pop() : null;
+
+        for (let j = 0; j < queryGroupings.length; j++) {
+            groupings.push({
+                Selectors: [...(lastGrouping?.Selectors ?? []), ...queryGroupings[j].Selectors],
+            });
         }
     }
 
-    return false;
+    return groupings;
 }
 
-// TODO: Rewrite everything into a attribute handler -> When scope gets added
-function handleKeyword(operator: Token, keyword: Token) {
-    const comparator = consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER, TokenType.SYMBOL]);
+/**
+ * Generates a query string from an array of selector groups.
+ * Each group is converted into a sub-query string, which are then concatenated
+ * into a final query string.
+ *
+ * @param groupings - An array of SelectorGroup objects representing grouped selectors.
+ * @returns A string representing the combined query built from the selector groups.
+ */
+function generateQuery(groupings: SelectorGroup[]): string {
     let query = '';
 
+    for (let i = 0; i < groupings.length; i++) {
+        let subQuery = '';
+
+        for (let j = 0; j < groupings[i].Selectors.length; j++) {
+            subQuery += groupings[i].Selectors[j].Value;
+        }
+
+        query += i === 0 ? subQuery : `, ${subQuery}`;
+    }
+
+    return query;
+}
+
+/**
+ * Constructs a Selector object from a given expression.
+ * This function interprets the expression's tokens to determine the type of selector
+ * (e.g., ID, class, tag, attribute) and its value. It handles special cases for
+ * different selector types and throws an error for unsupported types.
+ *
+ * @param expression - The Expression object containing tokens to be processed into a selector.
+ * @returns A Selector object representing a single CSS-like selector.
+ */
+function createSelector(expression: Expression): Selector {
+    const keyword = expression.consumeToken(TokenType.KEYWORD, [TokenType.FUNCTION]);
+    const comparator = expression.consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER, TokenType.SYMBOL]);
     let secondaryOperator: Token | undefined;
 
-    if (nextToken() && hasSecondaryOperator(comparator, nextToken())) {
-        secondaryOperator = consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER]);
+    if (expression.nextToken() && hasSecondaryOperator(comparator, expression.nextToken())) {
+        secondaryOperator = expression.consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER]);
     }
 
-    if (operator.Value == OperatorType.AND || operator.Value == SymbolType.AND) {
-        query += ''; // No spacing
-    } else if ((operator.Value = OperatorType.OR || operator.Value == SymbolType.OR)) {
-        query += '\u{0020}'; // Whitespace
-    }
-
-    const valueToken = consumeToken(TokenType.STRING);
+    const valueToken = expression.consumeToken(TokenType.STRING);
     const simpleComparatorType = getSimpleOperationType(comparator.Value, secondaryOperator?.Value ?? null);
 
-    if (keyword.Value === KeywordType.ID) {
-        if (simpleComparatorType === OperationType.EQUALS) {
-            query += `#${valueToken.Value}`;
-        } else if (simpleComparatorType === OperationType.NOT_EQUALS) {
-            query += `:not(#${valueToken.Value})`;
-        } else if (simpleComparatorType === OperationType.LIKE) {
-            // When you hit this, try to pass it along to the attribute handler. Works the same way
-            query += `[id*="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_LIKE) {
-            query += `:not([id*="${valueToken.Value}"])`;
-        }
+    let basicSelector = '';
+
+    if (keyword.Value === KeywordType.TAG || keyword.Value === KeywordType.ELEMENT) {
+        basicSelector = valueToken.Value;
+    } else if (keyword.Value === KeywordType.ID) {
+        basicSelector = getIdSelector(keyword, simpleComparatorType, valueToken);
     } else if (keyword.Value === KeywordType.CLASS) {
-        if (simpleComparatorType === OperationType.EQUALS) {
-            query += `.${valueToken.Value}`;
-        } else if (simpleComparatorType === OperationType.NOT_EQUALS) {
-            query += `:not(.${valueToken.Value})`;
-        } else if (simpleComparatorType === OperationType.LIKE) {
-            // When you hit this, try to pass it along to the attribute handler. Works the same way
-            query += `[class*="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_LIKE) {
-            query += `:not([class*="${valueToken.Value}"])`;
-        } else if (simpleComparatorType === OperationType.CONTAINS) {
-            query += `[class~="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_CONTAINS) {
-            query += `:not([class~="${valueToken.Value}"])`;
-        }
-    } else if (keyword.Value === KeywordType.STYLE) {
-        if (simpleComparatorType === OperationType.EQUALS) {
-            query += `[style="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_EQUALS) {
-            query += `:not([style="${valueToken.Value})"]`;
-        } else if (simpleComparatorType === OperationType.LIKE) {
-            // When you hit this, try to pass it along to the attribute handler. Works the same way
-            query += `[style*="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_LIKE) {
-            query += `:not([style*="${valueToken.Value}"])`;
-        } else if (simpleComparatorType === OperationType.CONTAINS) {
-            query += `[style~="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_CONTAINS) {
-            query += `:not([style~="${valueToken.Value}"])`;
-        }
-    } else if (keyword.Value === KeywordType.ATTRIBUTE) {
-        // Attribute = 'data-color' AND Attribute.Value = 'red' AND Attribute('data-color') = 'red'
-        if (simpleComparatorType === OperationType.EQUALS) {
-            query += `[${valueToken.Value}]`;
-        } else if (simpleComparatorType === OperationType.NOT_EQUALS) {
-            query += `:not([${valueToken.Value}])"]`;
-        } else if (simpleComparatorType === OperationType.LIKE) {
-            // When you hit this, try to pass it along to the attribute handler. Works the same way
-            query += `[style*="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_LIKE) {
-            query += `:not([style*="${valueToken.Value}"])`;
-        } else if (simpleComparatorType === OperationType.CONTAINS) {
-            query += `[style~="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_CONTAINS) {
-            query += `:not([style~="${valueToken.Value}"])`;
-        }
+        basicSelector = getClassSelector(keyword, simpleComparatorType, valueToken);
+    } else if (keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.STYLE) {
+        basicSelector = getAttributeSelector(keyword, simpleComparatorType, valueToken);
+    } else {
+        throw new Error(`Unable to handle foreign selector of type ${keyword.Value}.`);
     }
 
-    _queries.push(query);
+    return {
+        Value: basicSelector,
+        KeywordType: keyword.Value as KeywordType,
+        JoiningOperator: expression.JoiningOperator,
+    };
 }
 
-function handleFunction(operator: Token, directive: Token) {
-    const comparator = consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER, TokenType.SYMBOL]);
-    let query = '';
-
-    let secondaryOperator: Token | undefined;
-
-    if (nextToken() && hasSecondaryOperator(comparator, nextToken())) {
-        secondaryOperator = consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER]);
+/**
+ * Creates an attribute or style selector string based on the operation type.
+ * Handles different operation types (e.g., equals, like, contains) to generate the correct
+ * CSS selector format for attributes and styles.
+ *
+ * @param keyword - The token representing the attribute or style keyword.
+ * @param simpleComparatorType - The operation type to determine the comparison operator in the selector.
+ * @param valueToken - The token containing the attribute or style value.
+ * @returns A string representing the attribute selector in CSS format.
+ */
+function getAttributeSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
+    if (keyword.Value === KeywordType.ATTRIBUTE && keyword.Type !== TokenType.FUNCTION) {
+        return `[${valueToken.Value}]`;
     }
 
-    if (operator.Value == OperatorType.AND || operator.Value == SymbolType.AND) {
-        query += ''; // No spacing
-    } else if ((operator.Value = OperatorType.OR || operator.Value == SymbolType.OR)) {
-        query += '\u{0020}'; // Whitespace
+    const attributeName = keyword.Type === TokenType.FUNCTION ? (keyword?.Arguments?.[0] ?? '') : getAttributeName(keyword);
+    let selector = '';
+
+    switch (simpleComparatorType) {
+        case OperationType.EQUALS:
+        case OperationType.NOT_EQUALS:
+            selector = '=';
+            break;
+        case OperationType.LIKE:
+        case OperationType.NOT_LIKE:
+            selector = '*=';
+            break;
+        case OperationType.CONTAINS:
+        case OperationType.NOT_CONTAINS:
+            selector = '~=';
+            break;
+        default:
+            throw new Error(`Invalid simple comparator type: ${simpleComparatorType}`);
     }
 
-    if (directive.Value === KeywordType.ATTRIBUTE) {
-        if (!directive.Arguments || directive.Arguments.length < 1) {
-            throw new Error('Invalid arguments. Expected one argument, but got none.');
-        }
-
-        const valueToken = consumeToken(TokenType.STRING);
-        const simpleComparatorType = getSimpleOperationType(comparator.Value, secondaryOperator?.Value ?? null);
-        const attributeName = directive.Arguments[0];
-
-        if (simpleComparatorType === OperationType.EQUALS) {
-            query += `[${attributeName}="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_EQUALS) {
-            query += `:not([${attributeName}="${valueToken.Value}"])`;
-        } else if (simpleComparatorType === OperationType.LIKE) {
-            query += `[${attributeName}*="${valueToken.Value}"]`;
-        } else if (simpleComparatorType === OperationType.NOT_LIKE) {
-            query += `:not([${attributeName}*="${valueToken.Value}"])`;
-        } else if (simpleComparatorType === OperationType.CONTAINS) {
-            query += `[${attributeName}~="${valueToken.Value}"]`;
-        }
-    }
-
-    _queries.push(query);
+    return `[${attributeName}${selector}"${valueToken.Value}"]`;
 }
 
+/**
+ * Generates an ID selector string or falls back to an attribute selector if necessary.
+ * This function primarily creates ID selectors but uses attribute selectors for
+ * more complex comparison operations.
+ *
+ * @param keyword - The token representing the ID keyword.
+ * @param simpleComparatorType - The operation type to determine how the ID is compared.
+ * @param valueToken - The token containing the ID value.
+ * @returns A string representing the ID selector in CSS format, or an attribute selector if needed.
+ */
+function getIdSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
+    if (simpleComparatorType === OperationType.EQUALS || simpleComparatorType === OperationType.NOT_EQUALS) {
+        return `#${valueToken.Value}`;
+    } else {
+        return getAttributeSelector(keyword, simpleComparatorType, valueToken);
+    }
+}
+
+/**
+ * Generates a class selector string or falls back to an attribute selector if necessary.
+ * This function primarily creates class selectors but uses attribute selectors for
+ * more complex comparison operations.
+ *
+ * @param keyword - The token representing the class keyword.
+ * @param simpleComparatorType - The operation type to determine how the class is compared.
+ * @param valueToken - The token containing the class value.
+ * @returns A string representing the class selector in CSS format, or an attribute selector if needed.
+ */
+function getClassSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
+    if (simpleComparatorType === OperationType.EQUALS || simpleComparatorType === OperationType.NOT_EQUALS) {
+        return `.${valueToken.Value}`;
+    } else {
+        return getAttributeSelector(keyword, simpleComparatorType, valueToken);
+    }
+}
+
+/**
+ * Main parser function that processes an array of tokens into a structured query string.
+ * It builds expressions from tokens, groups selectors, and generates the final query string.
+ * This function integrates the overall parsing logic to transform raw tokens into a formatted query.
+ *
+ * @param tokens - An array of Token objects representing the input to be parsed.
+ * @returns A string representing the parsed and formatted query.
+ */
 function parser(tokens: Token[]): String {
-    _tokens = [...tokens];
+    const queryTokens = buildExpressions([...tokens]);
+    const groupings = groupSelectors(queryTokens);
+    const query = generateQuery(groupings);
 
-    consumeToken(TokenType.KEYWORD); // SELECT
-    consumeToken(TokenType.OPERATOR); // *
-    consumeToken(TokenType.KEYWORD); // FROM
-    consumeToken(TokenType.IDENTIFIER); // Dom
-    consumeToken(TokenType.KEYWORD); // WHERE
-
-    let hasFirstQueryBeenConsumed = false;
-
-    while (_tokens.length > 0) {
-        let operator: Token | null;
-
-        if (hasFirstQueryBeenConsumed) {
-            operator = consumeToken(TokenType.OPERATOR);
-        } else {
-            operator = { Type: TokenType.OPERATOR, Value: OperatorType.AND };
-            hasFirstQueryBeenConsumed = true;
-        }
-
-        const token = consumeToken(TokenType.KEYWORD, [TokenType.FUNCTION]);
-
-        if (token.Type === TokenType.KEYWORD) {
-            handleKeyword(operator, token);
-        } else if (token.Type === TokenType.FUNCTION) {
-            handleFunction(operator, token);
-        }
-    }
-
-    return _queries.join('');
+    return query;
 }
 
 export { parser };

--- a/src/parser/queryNotes.md
+++ b/src/parser/queryNotes.md
@@ -1,0 +1,23 @@
+### Compound Expression Reference (Basic)
+
+#### Javascript QuerySelector: `'a[href*="jellysql.com"], button[onclick*="jellysql.com"]'`
+``` sql
+SELECT * FROM DOM WHERE
+    (Tag = 'a' AND  Attribute('href') LIKE 'jellysql.com')
+ OR (Tag = 'button' AND Attribute('onclick') LIKE 'jellysql.com')
+```
+
+####  Javascript QuerySelector: `'a[href*="jellysql.com"], a[onclick*="jellysql.com"]'`
+```sql
+SELECT * FROM DOM WHERE
+    Tag = 'a'
+AND (Attribute('href') LIKE 'jellysql.com' OR Attribute('onclick') LIKE 'jellysql.com')
+ ```
+
+#### Javascript QuerySelector: `'a[href*="jellysql.com"][onclick*="jellysql.com"]'`
+```sql
+SELECT * FROM DOM WHERE
+    Tag = 'a'
+AND Attribute('href') LIKE 'jellysql.com'
+AND Attribute('onclick') LIKE 'jellysql.com'
+```

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,4 +1,4 @@
-import { OperatorType, Token } from '@/lexer/types';
+import { KeywordType, OperatorType, Token, TokenType } from '@/lexer/types';
 
 enum OperationType {
     UNKNOWN = 'UNKNOWN',
@@ -10,20 +10,57 @@ enum OperationType {
     NOT_LIKE = 'NOT_LIKE',
 }
 
-interface Expression {
+class Expression {
     Tokens: Token[];
-    JoiningOperator: OperatorType.AND | OperatorType.OR;
+    JoiningOperator: JoiningOperatorType;
+
+    constructor(tokens: Token[], joiningOperator: JoiningOperatorType) {
+        this.Tokens = tokens;
+        this.JoiningOperator = joiningOperator;
+    }
+
+    consumeToken(tokenType: TokenType, alternateTypes: TokenType[] | null = null): Token {
+        const token = this.Tokens.shift();
+
+        if (!token) {
+            throw new Error(`Invalid Type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but found no tokens in sequence.`);
+        } else if (token?.Type != tokenType && !alternateTypes?.includes(token?.Type)) {
+            if ((alternateTypes?.length ?? 0) > 0) {
+                throw new Error(`Invalid type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but got ${token?.Type} with value ${token?.Value}`);
+            } else {
+                throw new Error(`Invalid type. Expected ${tokenType}, but got ${token?.Type} with value ${token?.Value}`);
+            }
+        }
+
+        return token;
+    }
+
+    nextToken(): Token | null {
+        return this.Tokens.length > 0 ? this.Tokens[this.Tokens.length - 1] : null;
+    }
 }
+
+type JoiningOperatorType = OperatorType.AND | OperatorType.OR;
 
 interface CompoundExpression {
     Expressions: Expression[];
-    JoiningOperator: OperatorType.AND | OperatorType.OR;
+    JoiningOperator: JoiningOperatorType;
 }
 
 interface QueryToken {
-    Expression?: Expression | null;
-    CompoundExpression?: CompoundExpression | null;
+    Expressions: Expression[];
+    JoiningOperator?: JoiningOperatorType;
 }
 
-export { OperationType };
-export type { Expression, CompoundExpression, QueryToken };
+interface Selector {
+    Value: string;
+    KeywordType: KeywordType;
+    JoiningOperator: JoiningOperatorType;
+}
+
+interface SelectorGroup {
+    Selectors: Selector[];
+}
+
+export { OperationType, Expression };
+export type { CompoundExpression, QueryToken, Selector, SelectorGroup, JoiningOperatorType };

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,3 +1,5 @@
+import { OperatorType, Token } from '@/lexer/types';
+
 enum OperationType {
     UNKNOWN = 'UNKNOWN',
     EQUALS = 'EQUALS',
@@ -8,4 +10,20 @@ enum OperationType {
     NOT_LIKE = 'NOT_LIKE',
 }
 
+interface Expression {
+    Tokens: Token[];
+    JoiningOperator: OperatorType.AND | OperatorType.OR;
+}
+
+interface CompoundExpression {
+    Expressions: Expression[];
+    JoiningOperator: OperatorType.AND | OperatorType.OR;
+}
+
+interface QueryToken {
+    Expression?: Expression | null;
+    CompoundExpression?: CompoundExpression | null;
+}
+
 export { OperationType };
+export type { Expression, CompoundExpression, QueryToken };

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -1,0 +1,36 @@
+import { KeywordType, OperatorType, SymbolType, Token } from '@/lexer/types';
+
+import { OperationType } from './types';
+
+function getAttributeName(token: Token): string {
+    switch (token.Value) {
+        case KeywordType.ID:
+            return 'id';
+        case KeywordType.CLASS:
+            return 'class';
+        case KeywordType.STYLE:
+            return 'style';
+        default:
+            throw new Error(`Unable to parse attribute name. Expected keyword ${KeywordType.ID}, ${KeywordType.CLASS} or ${KeywordType.STYLE}.`);
+    }
+}
+
+function getSimpleOperationType(value: string, secondaryValue: string | null): OperationType {
+    if (value === SymbolType.ASSIGN || value === OperatorType.EQUALS || value === SymbolType.EQ) {
+        return OperationType.EQUALS;
+    } else if (value === SymbolType.NEQ || value === SymbolType.NEQ_LG || (value === OperatorType.NOT && secondaryValue === OperatorType.EQUALS)) {
+        return OperationType.NOT_EQUALS;
+    } else if (value === OperatorType.LIKE) {
+        return OperationType.LIKE;
+    } else if (value === OperatorType.NOT && secondaryValue === OperatorType.LIKE) {
+        return OperationType.NOT_LIKE;
+    } else if (value === OperatorType.CONTAINS) {
+        return OperationType.CONTAINS;
+    } else if (value === OperatorType.NOT && secondaryValue === OperationType.CONTAINS) {
+        return OperationType.NOT_CONTAINS;
+    }
+
+    return OperationType.UNKNOWN;
+}
+
+export { getAttributeName, getSimpleOperationType };

--- a/src/parser/validators.ts
+++ b/src/parser/validators.ts
@@ -1,0 +1,20 @@
+import { OperatorType, Token } from '@/lexer/types';
+
+function hasSecondaryOperator(operator: Token, nextToken: Token | null): Boolean {
+    if (nextToken == null) return false;
+
+    if (operator.Value === OperatorType.NOT) {
+        switch (nextToken.Value) {
+            case OperatorType.EQUALS:
+                return true;
+            case OperatorType.LIKE:
+                return true;
+            case OperatorType.CONTAINS:
+                return true;
+        }
+    }
+
+    return false;
+}
+
+export { hasSecondaryOperator };

--- a/src/style.css
+++ b/src/style.css
@@ -1,8 +1,8 @@
 #app {
-  color: #2c3e50;
-  font-family: Avenir, Helvetica, Arial, sans-serif;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-smoothing: antialiased;
-  margin-top: 60px;
-  text-align: center;
+    color: #2c3e50;
+    font-family: Avenir, Helvetica, Arial, sans-serif;
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    margin-top: 60px;
+    text-align: center;
 }

--- a/test/todo.test.ts
+++ b/test/todo.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it } from 'vitest';
 
-describe("todo", () => {
-  it("The jelly goes, jiggle-jiggle", () => {
-    expect("jelly-sql").toEqual("jelly-sql");
-  });
+describe('todo', () => {
+    it('The jelly goes, jiggle-jiggle', () => {
+        expect('jelly-sql').toEqual('jelly-sql');
+    });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,47 +1,47 @@
 /// <reference types="vitest" />
-import path from "path";
-import { defineConfig } from "vite";
+import path from 'path';
+import { defineConfig } from 'vite';
 
-import packageJson from "./package.json";
+import packageJson from './package.json';
 
 const getPackageName = () => {
-  return packageJson.name;
+    return packageJson.name;
 };
 
 const getPackageNameCamelCase = () => {
-  try {
-    return getPackageName().replace(/-./g, char => char[1].toUpperCase());
-  } catch (err) {
-    throw new Error("Name property in package.json is missing.");
-  }
+    try {
+        return getPackageName().replace(/-./g, char => char[1].toUpperCase());
+    } catch (err) {
+        throw new Error('Name property in package.json is missing.');
+    }
 };
 
 const fileName = {
-  es: `${getPackageName()}.js`,
-  iife: `${getPackageName()}.iife.js`,
+    es: `${getPackageName()}.js`,
+    iife: `${getPackageName()}.iife.js`,
 };
 
 const formats = Object.keys(fileName) as Array<keyof typeof fileName>;
 
 export default defineConfig({
-  base: "./",
-  build: {
-    outDir: "./build/dist",
-    lib: {
-      entry: path.resolve(__dirname, "src/index.ts"),
-      name: getPackageNameCamelCase(),
-      formats,
-      fileName: format => fileName[format],
+    base: './',
+    build: {
+        outDir: './build/dist',
+        lib: {
+            entry: path.resolve(__dirname, 'src/index.ts'),
+            name: getPackageNameCamelCase(),
+            formats,
+            fileName: format => fileName[format],
+        },
+        minify: true,
     },
-    minify: true
-  },
-  test: {
-    watch: false,
-  },
-  resolve: {
-    alias: [
-      { find: "@", replacement: path.resolve(__dirname, "src") },
-      { find: "@@", replacement: path.resolve(__dirname) },
-    ],
-  },
+    test: {
+        watch: false,
+    },
+    resolve: {
+        alias: [
+            { find: '@', replacement: path.resolve(__dirname, 'src') },
+            { find: '@@', replacement: path.resolve(__dirname) },
+        ],
+    },
 });


### PR DESCRIPTION
- Supports grouping basic selectors with `(` & `)`. ****Shallow groupings only***
- Tokens are now grouped as a `Expression`  and stored inside a `QueryToken`, which represents multiple selectors grouped together (compounds). Ex `A = 'B' AND (C = 'X' OR B <> 'Y')`
- When the queries (now transformed into `Selector` first) are parsed, it will obey the basic grouping behaviour of CSS selectors.
- Refactored the query builder to mostly rely on a single attribute handler.