### PR TITLE
Feat: Grouping expressions by `OR`

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,6 +5,7 @@
   "trailingComma": "es5",
   "arrowParens": "avoid",
   "bracketSpacing": true,
+  "bracketLine": true,
   "useTabs": false,
   "endOfLine": "auto",
   "singleAttributePerLine": false,

--- a/README.md
+++ b/README.md
@@ -33,10 +33,10 @@ Please see [Local Development](#Local-Development) for working with the source.
 
 ### TODO
 
-- ~~(***Active***) Extend attribute substring selectors~~
+- ~~ Extend attribute substring selectors~~
 - ~~Implement `:not()`~~
-- Force tag selectors to front of query
-- Resolve seelctors duplicating with multiple un-grouped `OR` operators
+- (***Next***) Force tag selectors to front of query
+- ~~(***Active***) Resolve seelctors duplicating with multiple un-grouped `OR` operators~~
 - Implement combinators, ex. ` `, `>`, `+`, `~`
 - Implement pseudo selectors
 - Improve type checking & syntax errors

--- a/package.json
+++ b/package.json
@@ -52,8 +52,5 @@
     "typescript": "^5.3.3",
     "vite": "^5.3.5",
     "vitest": "^2.0.4"
-  },
-  "prettier": {
-    "singleQuote": true
   }
 }

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -1,6 +1,3 @@
-import { lexer } from './lexer';
-import { parser } from './parser';
-
 /** Html element selectors
  *
  * - Tag
@@ -9,6 +6,9 @@ import { parser } from './parser';
  * - Class
  * - Style
  */
+
+import { lexer } from './lexer';
+import { parser } from './parser';
 
 /**HTML Elements
  *
@@ -155,31 +155,30 @@ import { parser } from './parser';
  */
 
 const sqlDomQuery = `SELECT * FROM DOM WHERE
-    Tag = 'a' AND  Attribute('href') LIKE 'jellysql.com'
- OR Tag = 'button' AND Attribute('onclick') LIKE 'jellysql.com'
-`;
+    (Tag = 'a' AND  Attribute('href') LIKE 'jellysql.com')
+ OR (Tag = 'button' AND Attribute('onclick') LIKE 'jellysql.com')`;
 
 const lexerTokens = lexer(sqlDomQuery);
-console.log(lexerTokens);
+console.log('Lexer Tokens: ', lexerTokens);
 
 const querySelector = parser(lexerTokens);
-console.log(querySelector);
+console.log('Query: ', querySelector);
 
 //manualQuerySelectorChecks();
 
 // @ts-ignore
 function manualQuerySelectorChecks() {
-  const querySelectors = [
-    '[id*="btn"]:not([id*="btn-confirm"])#a-confirm:not(#modal-delete-user).search-icon[class*="-primary"][class~="btn-primary"]:not([class~="btn-small"])[data-color="red"]',
-    'a[href*="jellysql.com"], a[onclick*="jellysql.com"]',
-    'a[href*="jellysql.com"][onclick*="jellysql.com"]',
-    'a[href*="jellysql.com"][onclick*="jellysql.com"], button[href*="jellysql.com"][onclick*="jellysql.com"]',
-    'a[href*="jellysql.com"] a[onclick*="jellysql.com"]',
-  ];
+    const querySelectors = [
+        '[id*="btn"]:not([id*="btn-confirm"])#a-confirm:not(#modal-delete-user).search-icon[class*="-primary"][class~="btn-primary"]:not([class~="btn-small"])[data-color="red"]',
+        'a[href*="jellysql.com"], a[onclick*="jellysql.com"]',
+        'a[href*="jellysql.com"][onclick*="jellysql.com"]',
+        'a[href*="jellysql.com"][onclick*="jellysql.com"], button[href*="jellysql.com"][onclick*="jellysql.com"]',
+        'a[href*="jellysql.com"] a[onclick*="jellysql.com"]',
+    ];
 
-  for (let i = 0; i < querySelectors.length; i++) {
-    const jsElements = document.querySelectorAll(querySelectors[i]);
+    for (let i = 0; i < querySelectors.length; i++) {
+        const jsElements = document.querySelectorAll(querySelectors[i]);
 
-    console.log(`${querySelectors[i]}: `, jsElements);
-  }
+        console.log(`${querySelectors[i]}: `, jsElements);
+    }
 }

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,20 +1,8 @@
-import {
-  KeywordType,
-  OperatorType,
-  SymbolType,
-  Token,
-  TokenType,
-} from '@/lexer/types';
+import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer/types';
 
 import { buildExpressions } from './expressionBuilder';
-import {
-  Expression,
-  OperationType,
-  QueryToken,
-  Selector,
-  SelectorGroup,
-} from './types';
-import { getAttributeName, getSimpleOperationType } from './utilities';
+import { Expression, OperationType, QueryToken, Selector, SelectorGroup } from './types';
+import { deepCopy, getAttributeName, getSimpleOperationType } from './utilities';
 import { hasSecondaryOperator } from './validators';
 
 /**
@@ -26,24 +14,24 @@ import { hasSecondaryOperator } from './validators';
  * @returns An array of SelectorGroup objects, each representing a logical group of selectors.
  */
 function createSelectors(queryToken: QueryToken): SelectorGroup[] {
-  let selectors: Selector[] = [];
-  let groupings: SelectorGroup[] = [];
+    let selectors: Selector[] = [];
+    let groupings: SelectorGroup[] = [];
 
-  for (let i = 0; i < queryToken.Expressions.length; i++) {
-    const selector = createSelector(queryToken.Expressions[i]);
+    for (let i = 0; i < queryToken.Expressions.length; i++) {
+        const selector = createSelector(queryToken.Expressions[i]);
 
-    if (selector.JoiningOperator === OperatorType.AND) {
-      selectors.push(selector);
-    } else {
-      groupings.push({ Selectors: [selector] });
+        if (selector.JoiningOperator === OperatorType.AND) {
+            selectors.push(selector);
+        } else {
+            groupings.push({ Selectors: [selector] });
+        }
     }
-  }
 
-  if (selectors.length > 0) {
-    groupings.unshift({ Selectors: selectors });
-  }
+    if (selectors.length > 0) {
+        groupings.unshift({ Selectors: selectors });
+    }
 
-  return groupings;
+    return groupings;
 }
 
 /**
@@ -55,26 +43,20 @@ function createSelectors(queryToken: QueryToken): SelectorGroup[] {
  * @returns An array of SelectorGroup objects, where each group represents a logical combination of selectors.
  */
 function groupSelectors(queryTokens: QueryToken[]): SelectorGroup[] {
-  let groupings: SelectorGroup[] = [];
+    let groupings: SelectorGroup[] = [];
 
-  for (let i = 0; i < queryTokens.length; i++) {
-    const queryGroupings = createSelectors(queryTokens[i]);
-    const lastGrouping =
-      queryTokens[i].JoiningOperator === OperatorType.AND
-        ? groupings.pop()
-        : null;
+    for (let i = 0; i < queryTokens.length; i++) {
+        const queryGroupings = createSelectors(queryTokens[i]);
+        const lastGrouping = queryTokens[i].JoiningOperator === OperatorType.AND ? groupings.pop() : null;
 
-    for (let j = 0; j < queryGroupings.length; j++) {
-      groupings.push({
-        Selectors: [
-          ...(lastGrouping?.Selectors ?? []),
-          ...queryGroupings[j].Selectors,
-        ],
-      });
+        for (let j = 0; j < queryGroupings.length; j++) {
+            groupings.push({
+                Selectors: [...(lastGrouping?.Selectors ?? []), ...queryGroupings[j].Selectors],
+            });
+        }
     }
-  }
 
-  return groupings;
+    return groupings;
 }
 
 /**
@@ -86,19 +68,19 @@ function groupSelectors(queryTokens: QueryToken[]): SelectorGroup[] {
  * @returns A string representing the combined query built from the selector groups.
  */
 function generateQuery(groupings: SelectorGroup[]): string {
-  let query = '';
+    let query = '';
 
-  for (let i = 0; i < groupings.length; i++) {
-    let subQuery = '';
+    for (let i = 0; i < groupings.length; i++) {
+        let subQuery = '';
 
-    for (let j = 0; j < groupings[i].Selectors.length; j++) {
-      subQuery += groupings[i].Selectors[j].Value;
+        for (let j = 0; j < groupings[i].Selectors.length; j++) {
+            subQuery += groupings[i].Selectors[j].Value;
+        }
+
+        query += i === 0 ? subQuery : `, ${subQuery}`;
     }
 
-    query += i === 0 ? subQuery : `, ${subQuery}`;
-  }
-
-  return query;
+    return query;
 }
 
 /**
@@ -111,70 +93,40 @@ function generateQuery(groupings: SelectorGroup[]): string {
  * @returns A Selector object representing a single CSS-like selector.
  */
 function createSelector(expression: Expression): Selector {
-  console.log(expression);
-  const keyword = expression.consumeToken(TokenType.KEYWORD, [
-    TokenType.FUNCTION,
-  ]);
-  const comparator = expression.consumeToken(TokenType.OPERATOR, [
-    TokenType.IDENTIFIER,
-    TokenType.SYMBOL,
-  ]);
-  let secondaryOperator: Token | undefined;
+    const keyword = expression.consumeToken(TokenType.KEYWORD, [TokenType.FUNCTION]);
+    const comparator = expression.consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER, TokenType.SYMBOL]);
+    let secondaryOperator: Token | undefined;
 
-  if (
-    expression.nextToken() &&
-    hasSecondaryOperator(comparator, expression.nextToken())
-  ) {
-    secondaryOperator = expression.consumeToken(TokenType.OPERATOR, [
-      TokenType.IDENTIFIER,
-    ]);
-  }
+    if (expression.nextToken() && hasSecondaryOperator(comparator, expression.nextToken())) {
+        secondaryOperator = expression.consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER]);
+    }
 
-  const valueToken = expression.consumeToken(TokenType.STRING);
-  const simpleComparatorType = getSimpleOperationType(
-    comparator.Value,
-    secondaryOperator?.Value ?? null,
-  );
+    const valueToken = expression.consumeToken(TokenType.STRING);
+    const simpleComparatorType = getSimpleOperationType(comparator.Value, secondaryOperator?.Value ?? null);
 
-  let basicSelector = '';
+    let basicSelector = '';
 
-  if (
-    keyword.Value === KeywordType.TAG ||
-    keyword.Value === KeywordType.ELEMENT
-  ) {
-    basicSelector = valueToken.Value;
-  } else if (keyword.Value === KeywordType.ID) {
-    basicSelector = getIdSelector(keyword, simpleComparatorType, valueToken);
-  } else if (keyword.Value === KeywordType.CLASS) {
-    basicSelector = getClassSelector(keyword, simpleComparatorType, valueToken);
-  } else if (
-    keyword.Value === KeywordType.ATTRIBUTE ||
-    keyword.Value === KeywordType.STYLE
-  ) {
-    basicSelector = getAttributeSelector(
-      keyword,
-      simpleComparatorType,
-      valueToken,
-    );
-  } else {
-    throw new Error(
-      `Unable to handle foreign selector of type ${keyword.Value}.`,
-    );
-  }
+    if (keyword.Value === KeywordType.TAG || keyword.Value === KeywordType.ELEMENT) {
+        basicSelector = valueToken.Value;
+    } else if (keyword.Value === KeywordType.ID) {
+        basicSelector = getIdSelector(keyword, simpleComparatorType, valueToken);
+    } else if (keyword.Value === KeywordType.CLASS) {
+        basicSelector = getClassSelector(keyword, simpleComparatorType, valueToken);
+    } else if (keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.STYLE) {
+        basicSelector = getAttributeSelector(keyword, simpleComparatorType, valueToken);
+    } else {
+        throw new Error(`Unable to handle foreign selector of type ${keyword.Value}.`);
+    }
 
-  if (
-    simpleComparatorType === OperationType.NOT_CONTAINS ||
-    simpleComparatorType === OperationType.NOT_EQUALS ||
-    simpleComparatorType === OperationType.NOT_LIKE
-  ) {
-    basicSelector = `:not(${basicSelector})`;
-  }
+    if (simpleComparatorType === OperationType.NOT_CONTAINS || simpleComparatorType === OperationType.NOT_EQUALS || simpleComparatorType === OperationType.NOT_LIKE) {
+        basicSelector = `:not(${basicSelector})`;
+    }
 
-  return {
-    Value: basicSelector,
-    KeywordType: keyword.Value as KeywordType,
-    JoiningOperator: expression.JoiningOperator,
-  };
+    return {
+        Value: basicSelector,
+        KeywordType: keyword.Value as KeywordType,
+        JoiningOperator: expression.JoiningOperator,
+    };
 }
 
 /**
@@ -187,59 +139,44 @@ function createSelector(expression: Expression): Selector {
  * @param valueToken - The token containing the attribute or style value.
  * @returns A string representing the attribute selector in CSS format.
  */
-function getAttributeSelector(
-  keyword: Token,
-  simpleComparatorType: OperationType,
-  valueToken: Token,
-): string {
-  if (
-    keyword.Value === KeywordType.ATTRIBUTE &&
-    keyword.Type !== TokenType.FUNCTION
-  ) {
-    return `[${valueToken.Value}]`;
-  }
+function getAttributeSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
+    if (keyword.Value === KeywordType.ATTRIBUTE && keyword.Type !== TokenType.FUNCTION) {
+        return `[${valueToken.Value}]`;
+    }
 
-  const attributeName =
-    keyword.Type === TokenType.FUNCTION
-      ? (keyword?.Arguments?.[0] ?? '')
-      : getAttributeName(keyword);
-  let selector = '';
+    const attributeName = keyword.Type === TokenType.FUNCTION ? (keyword?.Arguments?.[0] ?? '') : getAttributeName(keyword);
+    let selector = '';
 
-  switch (simpleComparatorType) {
-    case OperationType.EQUALS:
-    case OperationType.NOT_EQUALS:
-      selector = '=';
-      break;
-    case OperationType.LIKE:
-    case OperationType.NOT_LIKE:
-      const hasStart = valueToken.Value.startsWith(SymbolType.PERCENT);
-      const hasEnd = valueToken.Value.endsWith(SymbolType.PERCENT);
+    switch (simpleComparatorType) {
+        case OperationType.EQUALS:
+        case OperationType.NOT_EQUALS:
+            selector = '=';
+            break;
+        case OperationType.LIKE:
+        case OperationType.NOT_LIKE:
+            const hasStart = valueToken.Value.startsWith(SymbolType.PERCENT);
+            const hasEnd = valueToken.Value.endsWith(SymbolType.PERCENT);
 
-      if (hasStart && !hasEnd) {
-        selector = '^=';
-      } else if (!hasStart && hasEnd) {
-        selector = '$=';
-      } else {
-        selector = '*=';
-      }
+            if (hasStart && !hasEnd) {
+                selector = '^=';
+            } else if (!hasStart && hasEnd) {
+                selector = '$=';
+            } else {
+                selector = '*=';
+            }
 
-      valueToken.Value = valueToken.Value.slice(
-        hasStart ? 1 : 0,
-        hasEnd ? valueToken.Value.length - 1 : undefined,
-      );
+            valueToken.Value = valueToken.Value.slice(hasStart ? 1 : 0, hasEnd ? valueToken.Value.length - 1 : undefined);
 
-      break;
-    case OperationType.CONTAINS:
-    case OperationType.NOT_CONTAINS:
-      selector = '~=';
-      break;
-    default:
-      throw new Error(
-        `Invalid simple comparator type: ${simpleComparatorType}`,
-      );
-  }
+            break;
+        case OperationType.CONTAINS:
+        case OperationType.NOT_CONTAINS:
+            selector = '~=';
+            break;
+        default:
+            throw new Error(`Invalid simple comparator type: ${simpleComparatorType}`);
+    }
 
-  return `[${attributeName}${selector}"${valueToken.Value}"]`;
+    return `[${attributeName}${selector}"${valueToken.Value}"]`;
 }
 
 /**
@@ -252,19 +189,12 @@ function getAttributeSelector(
  * @param valueToken - The token containing the ID value.
  * @returns A string representing the ID selector in CSS format, or an attribute selector if needed.
  */
-function getIdSelector(
-  keyword: Token,
-  simpleComparatorType: OperationType,
-  valueToken: Token,
-): string {
-  if (
-    simpleComparatorType === OperationType.EQUALS ||
-    simpleComparatorType === OperationType.NOT_EQUALS
-  ) {
-    return `#${valueToken.Value}`;
-  } else {
-    return getAttributeSelector(keyword, simpleComparatorType, valueToken);
-  }
+function getIdSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
+    if (simpleComparatorType === OperationType.EQUALS || simpleComparatorType === OperationType.NOT_EQUALS) {
+        return `#${valueToken.Value}`;
+    } else {
+        return getAttributeSelector(keyword, simpleComparatorType, valueToken);
+    }
 }
 
 /**
@@ -277,19 +207,12 @@ function getIdSelector(
  * @param valueToken - The token containing the class value.
  * @returns A string representing the class selector in CSS format, or an attribute selector if needed.
  */
-function getClassSelector(
-  keyword: Token,
-  simpleComparatorType: OperationType,
-  valueToken: Token,
-): string {
-  if (
-    simpleComparatorType === OperationType.EQUALS ||
-    simpleComparatorType === OperationType.NOT_EQUALS
-  ) {
-    return `.${valueToken.Value}`;
-  } else {
-    return getAttributeSelector(keyword, simpleComparatorType, valueToken);
-  }
+function getClassSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
+    if (simpleComparatorType === OperationType.EQUALS || simpleComparatorType === OperationType.NOT_EQUALS) {
+        return `.${valueToken.Value}`;
+    } else {
+        return getAttributeSelector(keyword, simpleComparatorType, valueToken);
+    }
 }
 
 /**
@@ -301,15 +224,15 @@ function getClassSelector(
  * @returns A string representing the parsed and formatted query.
  */
 function parser(tokens: Token[]): String {
-  const queryTokens = buildExpressions([...tokens]);
-  console.log('Query Tokens: ', queryTokens);
+    const queryTokens = buildExpressions([...tokens]);
+    console.log('Query Tokens: ', deepCopy(queryTokens));
 
-  const groupings = groupSelectors(queryTokens);
-  console.log('Groupings: ', groupings);
+    const groupings = groupSelectors(queryTokens);
+    console.log('Groupings: ', groupings);
 
-  const query = generateQuery(groupings);
+    const query = generateQuery(groupings);
 
-  return query;
+    return query;
 }
 
 export { parser };

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -1,84 +1,66 @@
 import { KeywordType, OperatorType, Token, TokenType } from '@/lexer/types';
 
 enum OperationType {
-  UNKNOWN = 'UNKNOWN',
-  EQUALS = 'EQUALS',
-  NOT_EQUALS = 'NOT_EQUALS',
-  CONTAINS = 'CONTAINS',
-  NOT_CONTAINS = 'NOT_CONTAINS',
-  LIKE = 'LIKE',
-  NOT_LIKE = 'NOT_LIKE',
+    UNKNOWN = 'UNKNOWN',
+    EQUALS = 'EQUALS',
+    NOT_EQUALS = 'NOT_EQUALS',
+    CONTAINS = 'CONTAINS',
+    NOT_CONTAINS = 'NOT_CONTAINS',
+    LIKE = 'LIKE',
+    NOT_LIKE = 'NOT_LIKE',
 }
 
 class Expression {
-  Tokens: Token[];
-  JoiningOperator: JoiningOperatorType;
+    Tokens: Token[];
+    JoiningOperator: JoiningOperatorType;
 
-  constructor(tokens: Token[], joiningOperator: JoiningOperatorType) {
-    this.Tokens = tokens;
-    this.JoiningOperator = joiningOperator;
-  }
-
-  consumeToken(
-    tokenType: TokenType,
-    alternateTypes: TokenType[] | null = null,
-  ): Token {
-    const token = this.Tokens.shift();
-
-    if (!token) {
-      throw new Error(
-        `Invalid Type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but found no tokens in sequence.`,
-      );
-    } else if (
-      token?.Type != tokenType &&
-      !alternateTypes?.includes(token?.Type)
-    ) {
-      if ((alternateTypes?.length ?? 0) > 0) {
-        throw new Error(
-          `Invalid type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but got ${token?.Type} with value ${token?.Value}`,
-        );
-      } else {
-        throw new Error(
-          `Invalid type. Expected ${tokenType}, but got ${token?.Type} with value ${token?.Value}`,
-        );
-      }
+    constructor(tokens: Token[], joiningOperator: JoiningOperatorType) {
+        this.Tokens = tokens;
+        this.JoiningOperator = joiningOperator;
     }
 
-    return token;
-  }
+    consumeToken(tokenType: TokenType, alternateTypes: TokenType[] | null = null): Token {
+        const token = this.Tokens.shift();
 
-  nextToken(): Token | null {
-    return this.Tokens.length > 0 ? this.Tokens[0] : null;
-  }
+        if (!token) {
+            throw new Error(`Invalid Type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but found no tokens in sequence.`);
+        } else if (token?.Type != tokenType && !alternateTypes?.includes(token?.Type)) {
+            if ((alternateTypes?.length ?? 0) > 0) {
+                throw new Error(`Invalid type. Expected ${tokenType} or ${alternateTypes?.join(' or ')}, but got ${token?.Type} with value ${token?.Value}`);
+            } else {
+                throw new Error(`Invalid type. Expected ${tokenType}, but got ${token?.Type} with value ${token?.Value}`);
+            }
+        }
+
+        return token;
+    }
+
+    nextToken(): Token | null {
+        return this.Tokens.length > 0 ? this.Tokens[0] : null;
+    }
 }
 
 type JoiningOperatorType = OperatorType.AND | OperatorType.OR;
 
 interface CompoundExpression {
-  Expressions: Expression[];
-  JoiningOperator: JoiningOperatorType;
+    Expressions: Expression[];
+    JoiningOperator: JoiningOperatorType;
 }
 
 interface QueryToken {
-  Expressions: Expression[];
-  JoiningOperator?: JoiningOperatorType;
+    Expressions: Expression[];
+    JoiningOperator?: JoiningOperatorType;
 }
 
 interface Selector {
-  Value: string;
-  KeywordType: KeywordType;
-  JoiningOperator: JoiningOperatorType;
+    Value: string;
+    KeywordType: KeywordType;
+    JoiningOperator: JoiningOperatorType;
 }
 
 interface SelectorGroup {
-  Selectors: Selector[];
+    Selectors: Selector[];
 }
 
 export { OperationType, Expression };
-export type {
-  CompoundExpression,
-  QueryToken,
-  Selector,
-  SelectorGroup,
-  JoiningOperatorType,
-};
+export type { CompoundExpression, QueryToken, Selector, SelectorGroup, JoiningOperatorType };

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -3,78 +3,59 @@ import { KeywordType, OperatorType, SymbolType, Token } from '@/lexer/types';
 import { Expression, OperationType } from './types';
 
 function getAttributeName(token: Token): string {
-  switch (token.Value) {
-    case KeywordType.ID:
-      return 'id';
-    case KeywordType.CLASS:
-      return 'class';
-    case KeywordType.STYLE:
-      return 'style';
-    default:
-      throw new Error(
-        `Unable to parse attribute name. Expected keyword ${KeywordType.ID}, ${KeywordType.CLASS} or ${KeywordType.STYLE}.`,
-      );
-  }
+    switch (token.Value) {
+        case KeywordType.ID:
+            return 'id';
+        case KeywordType.CLASS:
+            return 'class';
+        case KeywordType.STYLE:
+            return 'style';
+        default:
+            throw new Error(`Unable to parse attribute name. Expected keyword ${KeywordType.ID}, ${KeywordType.CLASS} or ${KeywordType.STYLE}.`);
+    }
 }
 
-function getSimpleOperationType(
-  value: string,
-  secondaryValue: string | null,
-): OperationType {
-  if (
-    value === SymbolType.ASSIGN ||
-    value === OperatorType.EQUALS ||
-    value === SymbolType.EQ
-  ) {
-    return OperationType.EQUALS;
-  } else if (
-    value === SymbolType.NEQ ||
-    value === SymbolType.NEQ_LG ||
-    (value === OperatorType.NOT && secondaryValue === OperatorType.EQUALS)
-  ) {
-    return OperationType.NOT_EQUALS;
-  } else if (value === OperatorType.LIKE) {
-    return OperationType.LIKE;
-  } else if (
-    value === OperatorType.NOT &&
-    secondaryValue === OperatorType.LIKE
-  ) {
-    return OperationType.NOT_LIKE;
-  } else if (value === OperatorType.CONTAINS) {
-    return OperationType.CONTAINS;
-  } else if (
-    value === OperatorType.NOT &&
-    secondaryValue === OperationType.CONTAINS
-  ) {
-    return OperationType.NOT_CONTAINS;
-  }
+function getSimpleOperationType(value: string, secondaryValue: string | null): OperationType {
+    if (value === SymbolType.ASSIGN || value === OperatorType.EQUALS || value === SymbolType.EQ) {
+        return OperationType.EQUALS;
+    } else if (value === SymbolType.NEQ || value === SymbolType.NEQ_LG || (value === OperatorType.NOT && secondaryValue === OperatorType.EQUALS)) {
+        return OperationType.NOT_EQUALS;
+    } else if (value === OperatorType.LIKE) {
+        return OperationType.LIKE;
+    } else if (value === OperatorType.NOT && secondaryValue === OperatorType.LIKE) {
+        return OperationType.NOT_LIKE;
+    } else if (value === OperatorType.CONTAINS) {
+        return OperationType.CONTAINS;
+    } else if (value === OperatorType.NOT && secondaryValue === OperationType.CONTAINS) {
+        return OperationType.NOT_CONTAINS;
+    }
 
-  return OperationType.UNKNOWN;
+    return OperationType.UNKNOWN;
 }
 
 function deepCopy<T>(obj: T): T {
-  if (obj === null || typeof obj !== 'object') {
-    return obj;
-  }
-
-  if (obj instanceof Expression) {
-    const tokensCopy = deepCopy(obj.Tokens);
-    return new Expression(tokensCopy, obj.JoiningOperator) as unknown as T;
-  }
-
-  // If the object is an array, create a new array and deep copy each element
-  if (Array.isArray(obj)) {
-    return obj.map((item) => deepCopy(item)) as unknown as T;
-  }
-
-  const copy: any = {};
-  for (const key in obj) {
-    if (Object.prototype.hasOwnProperty.call(obj, key)) {
-      copy[key] = deepCopy(obj[key]);
+    if (obj === null || typeof obj !== 'object') {
+        return obj;
     }
-  }
 
-  return copy;
+    if (obj instanceof Expression) {
+        const tokensCopy = deepCopy(obj.Tokens);
+        return new Expression(tokensCopy, obj.JoiningOperator) as unknown as T;
+    }
+
+    // If the object is an array, create a new array and deep copy each element
+    if (Array.isArray(obj)) {
+        return obj.map(item => deepCopy(item)) as unknown as T;
+    }
+
+    const copy: any = {};
+    for (const key in obj) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+            copy[key] = deepCopy(obj[key]);
+        }
+    }
+
+    return copy;
 }
 
 export { getAttributeName, getSimpleOperationType, deepCopy };


### PR DESCRIPTION
- When no parathesis is found, the `expressionBuilder()` will group `AND` expressions. In layman's terms, split them by `OR` & parse a `OR` as a `) OR (`.