### PR TITLE
feat: Sort selectors by keyword priority in `groupSelectors` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Please see [Local Development](#Local-Development) for working with the source.
 
 - ~~ Extend attribute substring selectors~~
 - ~~Implement `:not()`~~
-- (***Next***) Force tag selectors to front of query
-- ~~(***Active***) Resolve seelctors duplicating with multiple un-grouped `OR` operators~~
-- Implement combinators, ex. ` `, `>`, `+`, `~`
+- ~~(***Active***) Force tag selectors to front of query~~
+- ~~Resolve selectors duplicating with multiple un-grouped `OR` operators~~
+- (***Next***)Implement combinators, ex. ` `, `>`, `+`, `~`
 - Implement pseudo selectors
 - Improve type checking & syntax errors
 - Unit testing

--- a/src/parser/constants.ts
+++ b/src/parser/constants.ts
@@ -1,0 +1,10 @@
+import { KeywordType } from '@/lexer/types';
+
+const keywordPriority: { [key: string]: number } = {
+    [KeywordType.TAG]: 1,
+    [KeywordType.ELEMENT]: 2,
+    [KeywordType.ID]: 3,
+    [KeywordType.CLASS]: 4,
+};
+
+export { keywordPriority };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -1,5 +1,6 @@
 import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer/types';
 
+import { keywordPriority } from './constants';
 import { buildExpressions } from './expressionBuilder';
 import { Expression, OperationType, QueryToken, Selector, SelectorGroup } from './types';
 import { deepCopy, getAttributeName, getSimpleOperationType } from './utilities';
@@ -54,6 +55,16 @@ function groupSelectors(queryTokens: QueryToken[]): SelectorGroup[] {
                 Selectors: [...(lastGrouping?.Selectors ?? []), ...queryGroupings[j].Selectors],
             });
         }
+    }
+
+    for (let i = 0; i < groupings.length; i++) {
+        groupings[i].Selectors = groupings[i].Selectors.sort((a, b) => {
+            if (keywordPriority[a.KeywordType] && keywordPriority[b.KeywordType]) {
+                return keywordPriority[a.KeywordType] - keywordPriority[b.KeywordType];
+            }
+
+            return 0;
+        });
     }
 
     return groupings;


### PR DESCRIPTION
- Keyword priority in queries. Ex. Tags will always appear before other selectors. Next are IDs, then classes, attributes, etc.