### PR TITLE
Extend test cases & support for simple cross apply queries

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ node_modules
 *.json
 *.md
 *.html
+.github/*

--- a/index.html
+++ b/index.html
@@ -25,5 +25,6 @@
             </div>
         </div>
         <script type="module" src="/src/index.ts"></script>
+        <script type="module" src="/src/localTesting.ts"></script>
     </body>
 </html>

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,3 @@ export function query(sql: string) {
 
     return querySelector;
 }
-
-export * from './localTesting';

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -12,6 +12,7 @@ const keywords: { [key: string]: TokenType } = {
     [KeywordType.ID]: TokenType.KEYWORD,
     [KeywordType.CLASS]: TokenType.KEYWORD,
     [KeywordType.ATTRIBUTE]: TokenType.KEYWORD,
+    [KeywordType.ATTR]: TokenType.KEYWORD,
     [KeywordType.STYLE]: TokenType.KEYWORD,
 } as const;
 
@@ -32,6 +33,7 @@ const operators: { [key: string]: TokenType } = {
 
 const functions: { [key: string]: TokenType } = {
     [FunctionType.ATTRIBUTE]: TokenType.FUNCTION,
+    [FunctionType.ATTR]: TokenType.FUNCTION,
 };
 
 /** ------ Regex ------ */

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -23,7 +23,8 @@ enum KeywordType {
     ELEMENT = 'ELEMENT', // ELEMENT == TAG
     ID = 'ID',
     CLASS = 'CLASS',
-    ATTRIBUTE = 'ATTRIBUTE',
+    ATTRIBUTE = 'ATTRIBUTE', // ATTRIBUTE == ATR
+    ATTR = 'ATTR', // ATR == ATTRIBUTE
     STYLE = 'STYLE',
 }
 
@@ -37,7 +38,8 @@ enum OperatorType {
 }
 
 enum FunctionType {
-    ATTRIBUTE = 'ATTRIBUTE',
+    ATTRIBUTE = 'ATTRIBUTE', // ATTRIBUTE == ATR
+    ATTR = 'ATTR', // ATR == ATTRIBUTE
     TAG = 'TAG',
 }
 

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -154,7 +154,14 @@ import { parser } from './parser';
     AND Attribute('data-color') = 'red'
  */
 
-const sqlDomQuery = `SELECT * FROM DOM WHERE ATTRIBUTE('element_width') like '90[%]%'`;
+const sqlDomQuery = `SELECT * FROM DOM WHERE
+    TAG = 'a'
+    AND (
+            CLASS = 'active'
+            OR CLASS = 'link'
+            OR ATTR <> 'disabled'
+        )
+`;
 
 const lexerTokens = lexer(sqlDomQuery);
 console.log('Lexer Tokens: ', lexerTokens);

--- a/src/parser/constants.ts
+++ b/src/parser/constants.ts
@@ -2,9 +2,11 @@ import { KeywordType } from '@/lexer/types';
 
 const keywordPriority: { [key: string]: number } = {
     [KeywordType.TAG]: 1,
-    [KeywordType.ELEMENT]: 2,
-    [KeywordType.ID]: 3,
-    [KeywordType.CLASS]: 4,
+    [KeywordType.ELEMENT]: 1,
+    [KeywordType.ID]: 2,
+    [KeywordType.CLASS]: 3,
+    [KeywordType.ATTRIBUTE]: 5,
+    [KeywordType.ATTR]: 5,
 };
 
 export { keywordPriority };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -18,18 +18,22 @@ function createSelectors(queryToken: QueryToken): SelectorGroup[] {
     let selectors: Selector[] = [];
     let groupings: SelectorGroup[] = [];
 
+    let previousSelector: Selector | null = null;
+
     for (let i = 0; i < queryToken.Expressions.length; i++) {
         const selector = createSelector(queryToken.Expressions[i]);
 
-        if (selector.JoiningOperator === OperatorType.AND) {
-            selectors.push(selector);
-        } else {
-            groupings.push({ Selectors: [selector] });
+        if (selector.JoiningOperator === OperatorType.OR && (previousSelector?.JoiningOperator === OperatorType.AND || previousSelector?.JoiningOperator === OperatorType.OR)) {
+            groupings.push({ Selectors: [...selectors] });
+            selectors = [];
         }
+
+        selectors.push(selector);
+        previousSelector = selector;
     }
 
     if (selectors.length > 0) {
-        groupings.unshift({ Selectors: selectors });
+        groupings.push({ Selectors: selectors });
     }
 
     return groupings;

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -125,10 +125,10 @@ function createSelector(expression: Expression): Selector {
     } else if (keyword.Value === KeywordType.CLASS) {
         const valueToken = expression.consumeToken(TokenType.STRING, [TokenType.NUMERIC]);
         basicSelector = getClassSelector(keyword, simpleComparatorType, valueToken);
-    } else if (keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.STYLE) {
+    } else if (keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.ATTR || keyword.Value === KeywordType.STYLE) {
         let alternateTypes: TokenType[] | null = null;
 
-        if (keyword.Value === KeywordType.ATTRIBUTE && keyword.Type === TokenType.FUNCTION) {
+        if ((keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.ATTR) && keyword.Type === TokenType.FUNCTION) {
             alternateTypes = [TokenType.NUMERIC];
         }
 
@@ -161,7 +161,7 @@ function createSelector(expression: Expression): Selector {
  * @returns A string representing the attribute selector in CSS format.
  */
 function getAttributeSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
-    if (keyword.Value === KeywordType.ATTRIBUTE && keyword.Type !== TokenType.FUNCTION) {
+    if ((keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.ATTR) && keyword.Type !== TokenType.FUNCTION) {
         return `[${valueToken.Value}]`;
     }
 

--- a/test/parser/index.test.ts
+++ b/test/parser/index.test.ts
@@ -302,8 +302,8 @@ describe('QuerySelector Generator', () => {
             });
         });
 
-        describe('ATTRIBUTE', () => {
-            const keywords = [KeywordType.ATTRIBUTE];
+        describe('ATTRIBUTE | ATTR', () => {
+            const keywords = [KeywordType.ATTRIBUTE, KeywordType.ATTR];
 
             test('Valid - Name match', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
@@ -616,5 +616,9 @@ describe('QuerySelector Generator', () => {
                 }
             });
         });
+    });
+
+    describe('Extended Intermediate', () => {
+        test('');
     });
 });

--- a/test/parser/index.test.ts
+++ b/test/parser/index.test.ts
@@ -4,6 +4,10 @@ import { query } from '../../src/index';
 import { KeywordType, OperatorType, SymbolType } from '../../src/lexer/types';
 
 describe('QuerySelector Generator', () => {
+    test('The jelly goes, jiggle-jiggle', () => {
+        expect('jelly-sql').toEqual('jelly-sql');
+    });
+
     describe('Isolated Basic', () => {
         const generateLowerCaseVariations = (arr: string[]) => [...arr, ...arr.map(x => x.toLowerCase())];
 
@@ -24,7 +28,7 @@ describe('QuerySelector Generator', () => {
         describe('TAG | ELEMENT', () => {
             const keywords = [KeywordType.TAG, KeywordType.ELEMENT];
 
-            test('Valid - Equals; Not Equals', () => {
+            test('Equals; Not Equals', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
                 const notEqualOperators = [SymbolType.NEQ, SymbolType.NEQ_LG, `${OperatorType.NOT} ${OperatorType.EQUALS}`];
 
@@ -63,7 +67,7 @@ describe('QuerySelector Generator', () => {
         describe('ID', () => {
             const keywords = [KeywordType.ID];
 
-            test('Valid - Equals; Not Equals', () => {
+            test('Equals; Not Equals', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
                 const notEqualOperators = [SymbolType.NEQ, SymbolType.NEQ_LG, `${OperatorType.NOT} ${OperatorType.EQUALS}`];
 
@@ -98,7 +102,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Like; Not Like', () => {
+            test('Like; Not Like', () => {
                 const likeOperators = [OperatorType.LIKE];
                 const notEqualOperators = [`${OperatorType.NOT} ${OperatorType.LIKE}`];
 
@@ -145,7 +149,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Contains; Not Contains', () => {
+            test('Contains; Not Contains', () => {
                 const containOperators = [OperatorType.CONTAINS];
                 const notContainOperators = [`${OperatorType.NOT} ${OperatorType.CONTAINS}`];
 
@@ -184,7 +188,7 @@ describe('QuerySelector Generator', () => {
         describe('CLASS', () => {
             const keywords = [KeywordType.CLASS];
 
-            test('Valid - Equals; Not Equals', () => {
+            test('Equals; Not Equals', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
                 const notEqualOperators = [SymbolType.NEQ, SymbolType.NEQ_LG, `${OperatorType.NOT} ${OperatorType.EQUALS}`];
 
@@ -219,7 +223,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Like; Not Like', () => {
+            test('Like; Not Like', () => {
                 const likeOperators = [OperatorType.LIKE];
                 const notEqualOperators = [`${OperatorType.NOT} ${OperatorType.LIKE}`];
 
@@ -266,7 +270,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Contains; Not Contains', () => {
+            test('Contains; Not Contains', () => {
                 const containOperators = [OperatorType.CONTAINS];
                 const notContainOperators = [`${OperatorType.NOT} ${OperatorType.CONTAINS}`];
 
@@ -305,7 +309,7 @@ describe('QuerySelector Generator', () => {
         describe('ATTRIBUTE | ATTR', () => {
             const keywords = [KeywordType.ATTRIBUTE, KeywordType.ATTR];
 
-            test('Valid - Name match', () => {
+            test('Name match', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
                 const notEqualOperators = [SymbolType.NEQ, SymbolType.NEQ_LG, `${OperatorType.NOT} ${OperatorType.EQUALS}`];
 
@@ -340,7 +344,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Equals; Not Equals', () => {
+            test('Equals; Not Equals', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
                 const notEqualOperators = [SymbolType.NEQ, SymbolType.NEQ_LG, `${OperatorType.NOT} ${OperatorType.EQUALS}`];
 
@@ -377,7 +381,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Like; Not Like', () => {
+            test('Like; Not Like', () => {
                 const likeOperators = [OperatorType.LIKE];
                 const notEqualOperators = [`${OperatorType.NOT} ${OperatorType.LIKE}`];
 
@@ -436,7 +440,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Contains; Not Contains', () => {
+            test('Contains; Not Contains', () => {
                 const containOperators = [OperatorType.CONTAINS];
                 const notContainOperators = [`${OperatorType.NOT} ${OperatorType.CONTAINS}`];
 
@@ -477,7 +481,7 @@ describe('QuerySelector Generator', () => {
         describe('STYLE', () => {
             const keywords = [KeywordType.STYLE];
 
-            test('Valid - Equals; Not Equals', () => {
+            test('Equals; Not Equals', () => {
                 const equalOperators = [SymbolType.ASSIGN, SymbolType.EQ, OperatorType.EQUALS];
                 const notEqualOperators = [SymbolType.NEQ, SymbolType.NEQ_LG, `${OperatorType.NOT} ${OperatorType.EQUALS}`];
 
@@ -517,7 +521,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Like; Not Like', () => {
+            test('Like; Not Like', () => {
                 const likeOperators = [OperatorType.LIKE];
                 const notEqualOperators = [`${OperatorType.NOT} ${OperatorType.LIKE}`];
 
@@ -576,7 +580,7 @@ describe('QuerySelector Generator', () => {
                 }
             });
 
-            test('Valid - Contains; Not Contains', () => {
+            test('Contains; Not Contains', () => {
                 const containOperators = [OperatorType.CONTAINS];
                 const notContainOperators = [`${OperatorType.NOT} ${OperatorType.CONTAINS}`];
 
@@ -619,6 +623,83 @@ describe('QuerySelector Generator', () => {
     });
 
     describe('Extended Intermediate', () => {
-        test('');
+        test('Keyword Order Priority', () => {
+            const testCases = [
+                { input: `TAG = 'a' AND ID = 'confirm-link'`, expected: `a#confirm-link` },
+                { input: `TAG = 'a' AND CLASS = 'btn-blue'`, expected: `a.btn-blue` },
+                { input: `TAG = 'a' AND ID = 'confirm-link' AND CLASS = 'btn-blue'`, expected: `a#confirm-link.btn-blue` },
+                { input: `ID = 'confirm-link' AND TAG = 'a'`, expected: `a#confirm-link` },
+                { input: `CLASS = 'btn-blue' AND TAG = 'a'`, expected: `a.btn-blue` },
+                { input: `CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a'`, expected: `a#confirm-link.btn-blue` },
+                { input: `ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a'`, expected: `a#confirm-link.btn-blue[value="ready"]` },
+            ];
+
+            for (const { input, expected } of testCases) {
+                const queryString = `SELECT * FROM DOM WHERE ${input}`;
+
+                expect(query(queryString)).toBe(expected);
+            }
+        });
+
+        test('Auto Groupings (AND | OR)', () => {
+            const testCases = [
+                { input: `TAG = 'a' OR CLASS = 'link'`, expected: `a, .link` },
+                { input: `TAG = 'a' AND CLASS = 'active' OR CLASS = 'link'`, expected: `a.active, .link` },
+                { input: `TAG = 'a' AND CLASS = 'active' OR CLASS = 'link' OR TAG = 'button'`, expected: `a.active, .link, button` },
+                { input: `TAG = 'a' AND CLASS = 'active' OR CLASS = 'link' OR TAG = 'button' AND ID = 'to-top-link'`, expected: `a.active, .link, button#to-top-link` },
+                {
+                    input: `TAG = 'a' AND CLASS = 'active' OR CLASS = 'link' AND TAG = 'a' OR TAG = 'button' AND ID = 'to-top-link'`,
+                    expected: `a.active, a.link, button#to-top-link`,
+                },
+            ];
+
+            for (const { input, expected } of testCases) {
+                const queryString = `SELECT * FROM DOM WHERE ${input}`;
+
+                expect(query(queryString)).toBe(expected);
+            }
+        });
+
+        describe('Shallow Groupings with Braces (AND | OR)', () => {
+            test('Manual Braces Must Match Auto Groupings', () => {
+                const testCases = [
+                    /* Original subset from test "Groupings (AND | OR)" */
+                    { input: `(TAG = 'a') OR (CLASS = 'link')`, expected: `a, .link` },
+                    { input: `(TAG = 'a' AND CLASS = 'active') OR (CLASS = 'link')`, expected: `a.active, .link` },
+                    { input: `(TAG = 'a' AND CLASS = 'active') OR (CLASS = 'link') OR (TAG = 'button')`, expected: `a.active, .link, button` },
+                    { input: `(TAG = 'a' AND CLASS = 'active') OR (CLASS = 'link') OR (TAG = 'button' AND ID = 'to-top-link')`, expected: `a.active, .link, button#to-top-link` },
+                    {
+                        input: `(TAG = 'a' AND CLASS = 'active') OR (CLASS = 'link' AND TAG = 'a') OR (TAG = 'button' AND ID = 'to-top-link')`,
+                        expected: `a.active, a.link, button#to-top-link`,
+                    },
+                ];
+
+                for (const { input, expected } of testCases) {
+                    const queryString = `SELECT * FROM DOM WHERE ${input}`;
+
+                    expect(query(queryString)).toBe(expected);
+                }
+            });
+
+            test('Single [AND] Cross Apply with [OR] Grouping', () => {
+                const testCases = [
+                    { input: `TAG = 'a' AND (CLASS = 'active' OR CLASS = 'link' AND ID = 'old-link')`, expected: `a.active, a#old-link.link` },
+                    { input: `TAG = 'a' AND (CLASS = 'active' AND ID = 'new-link' OR CLASS = 'link')`, expected: `a#new-link.active, a.link` },
+                    { input: `TAG = 'a' AND (CLASS = 'active' AND ID = 'new-link' OR CLASS = 'link' AND ID = 'old-link')`, expected: `a#new-link.active, a#old-link.link` },
+                    {
+                        input: `CLASS = 'orange' AND TAG = 'a' AND (CLASS = 'active' AND ID = 'new-link' OR CLASS = 'link' AND ID = 'old-link')`,
+                        expected: `a#new-link.orange.active, a#old-link.orange.link`,
+                    },
+                    { input: `TAG = 'a' AND (CLASS = 'active' OR CLASS = 'link' OR ATTR <> 'disabled')`, expected: `a.active, a.link, a:not([disabled])` },
+                    // {input: `(CLASS = 'active' AND ID = 'new-link' OR CLASS = 'link' AND ID = 'old-link') AND TAG = 'a'`, expected: `a#new-link.active, a#old-link.link`}, // TODO: Add support for adding post multiply
+                ];
+
+                for (const { input, expected } of testCases) {
+                    const queryString = `SELECT * FROM DOM WHERE ${input}`;
+
+                    expect(query(queryString)).toBe(expected);
+                }
+            });
+        });
     });
 });

--- a/test/todo.test.ts
+++ b/test/todo.test.ts
@@ -1,7 +1,0 @@
-import { describe, expect, it } from 'vitest';
-
-describe('todo', () => {
-    it('The jelly goes, jiggle-jiggle', () => {
-        expect('jelly-sql').toEqual('jelly-sql');
-    });
-});


### PR DESCRIPTION
- Appended test cases to cater for more complex queries with groupings
- Added an abbreviated version of `ATTRIBUTE` as `ATTR`. It was getting tedious to write it out in full
- You can now cross-apply simple groupings. It makes writing queries that share the same selectors a lot quicker.

To achieve the below CSS query selector:
```css
a.active.link, a#deprecated-link.active.btn-link
```

Previously you had to write:
```sql
... WHERE 
        (TAG = 'a' AND CLASS = 'active' AND CLASS = 'link')
        OR (TAG = 'a' AND CLASS = 'active' AND ID = 'deprecated-link' AND CLASS = 'btn-link')
```

Now you can reduce and write:
```sql
... WHERE 
        TAG = 'a' AND CLASS = 'active'
        AND (CLASS = 'link' OR ID = 'deprecated-link' AND CLASS = 'btn-link')
```