### PR TITLE
Feature/combintaors initial

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Please see [Local Development](#Local-Development) for working with the source.
 - ~~Implement `:not()`~~
 - ~~Force tag selectors to front of query~~
 - ~~Resolve selectors duplicating with multiple un-grouped `OR` operators~~
-- (***Active***)Implement combinators, ex. ` `, `>`, `+`, `~`
-- (***Next***)Implement pseudo selectors
+- ~~Implement combinators, ex. ` `, `>`, `+`, `~`~~
+- (***Next***) Add support for nested groupings of `(...)`
+- (***Active***) Implement pseudo selectors
 - Improve type checking & syntax errors
 - ~~Unit testing~~
 - Support escaping characters?

--- a/README.md
+++ b/README.md
@@ -37,10 +37,10 @@ Please see [Local Development](#Local-Development) for working with the source.
 - ~~Implement `:not()`~~
 - ~~Force tag selectors to front of query~~
 - ~~Resolve selectors duplicating with multiple un-grouped `OR` operators~~
-- (***Next***)Implement combinators, ex. ` `, `>`, `+`, `~`
-- Implement pseudo selectors
+- (***Active***)Implement combinators, ex. ` `, `>`, `+`, `~`
+- (***Next***)Implement pseudo selectors
 - Improve type checking & syntax errors
-- (***Active***)Unit testing
+- ~~Unit testing~~
 - Support escaping characters?
 
 ## Local Development

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -29,7 +29,14 @@ const operators: { [key: string]: TokenType } = {
     [OperatorType.NOT]: TokenType.OPERATOR,
     [OperatorType.LIKE]: TokenType.OPERATOR,
     [OperatorType.CONTAINS]: TokenType.OPERATOR,
+    [OperatorType.CHILD]: TokenType.OPERATOR,
+    [OperatorType.SIBLING]: TokenType.OPERATOR,
+    [OperatorType.WITHIN]: TokenType.OPERATOR,
+    [OperatorType.OF]: TokenType.OPERATOR,
+    [OperatorType.TO]: TokenType.OPERATOR,
 } as const;
+
+const logicalOperators: OperatorType[] = [OperatorType.AND, OperatorType.OR];
 
 const functions: { [key: string]: TokenType } = {
     [FunctionType.ATTRIBUTE]: TokenType.FUNCTION,
@@ -48,4 +55,4 @@ const Regex = {
     function: /^\w+\s*\([^)]*\)/,
 };
 
-export { Regex, keywords, operators, functions };
+export { Regex, keywords, operators, logicalOperators, functions };

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -31,17 +31,28 @@ const operators: { [key: string]: TokenType } = {
     [OperatorType.CONTAINS]: TokenType.OPERATOR,
     [OperatorType.CHILD]: TokenType.OPERATOR,
     [OperatorType.SIBLING]: TokenType.OPERATOR,
+    [OperatorType.NEXT]: TokenType.OPERATOR,
     [OperatorType.WITHIN]: TokenType.OPERATOR,
     [OperatorType.OF]: TokenType.OPERATOR,
     [OperatorType.TO]: TokenType.OPERATOR,
+    [OperatorType.CHILD_OF]: TokenType.OPERATOR,
+    [OperatorType.NEXT_TO]: TokenType.OPERATOR,
+    [OperatorType.SIBLING_OF]: TokenType.OPERATOR,
 } as const;
-
-const logicalOperators: OperatorType[] = [OperatorType.AND, OperatorType.OR];
 
 const functions: { [key: string]: TokenType } = {
     [FunctionType.ATTRIBUTE]: TokenType.FUNCTION,
     [FunctionType.ATTR]: TokenType.FUNCTION,
+    [FunctionType.TAG]: TokenType.FUNCTION,
 };
+
+const tokenSequenceReplaceables: { [key: string]: OperatorType[] } = {
+    [OperatorType.CHILD_OF]: [OperatorType.CHILD, OperatorType.OF],
+    [OperatorType.NEXT_TO]: [OperatorType.NEXT, OperatorType.TO],
+    [OperatorType.SIBLING_OF]: [OperatorType.SIBLING, OperatorType.OF],
+};
+
+const orOperatorSubstitutes = [OperatorType.CHILD_OF, OperatorType.SIBLING_OF, OperatorType.NEXT_TO, OperatorType.WITHIN] as const;
 
 /** ------ Regex ------ */
 
@@ -55,4 +66,4 @@ const Regex = {
     function: /^\w+\s*\([^)]*\)/,
 };
 
-export { Regex, keywords, operators, logicalOperators, functions };
+export { Regex, keywords, operators, functions, tokenSequenceReplaceables, orOperatorSubstitutes };

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -43,6 +43,9 @@ enum OperatorType {
     WITHIN = 'WITHIN',
     OF = 'OF',
     TO = 'TO',
+    CHILD_OF = 'CHILD OF',
+    NEXT_TO = 'NEXT TO',
+    SIBLING_OF = 'SIBLING OF',
 }
 
 enum FunctionType {
@@ -76,6 +79,7 @@ enum SymbolType {
     DIVIDE = '/',
 
     PERCENT = '%',
+    TILDE = '~',
 
     ASSIGN = '=',
     AND = '&&',

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -35,6 +35,14 @@ enum OperatorType {
     NOT = 'NOT',
     LIKE = 'LIKE',
     CONTAINS = 'CONTAINS',
+
+    /* Combinators */
+    CHILD = 'CHILD',
+    SIBLING = 'SIBLING',
+    NEXT = 'NEXT',
+    WITHIN = 'WITHIN',
+    OF = 'OF',
+    TO = 'TO',
 }
 
 enum FunctionType {
@@ -46,6 +54,9 @@ enum FunctionType {
 enum CompoundType {
     NOT_EQUALS = 'NOT EQUALS',
     NOT_LIKE = 'NOT LIKE',
+    CHILD_OF = 'CHILD OF',
+    NEXT_TO = 'NEXT TO',
+    SIBLING_OF = 'SIBLING OF',
 }
 
 enum SymbolType {

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -155,12 +155,7 @@ import { parser } from './parser';
  */
 
 const sqlDomQuery = `SELECT * FROM DOM WHERE
-    TAG('a')
-    AND (
-            CLASS = 'active'
-            OR CLASS = 'link'
-            OR ATTR <> 'disabled'
-        )
+TAG('p') WITHIN TAG('div')
 `;
 
 const lexerTokens = lexer(sqlDomQuery);

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -155,7 +155,7 @@ import { parser } from './parser';
  */
 
 const sqlDomQuery = `SELECT * FROM DOM WHERE
-    TAG = 'a'
+    TAG('a')
     AND (
             CLASS = 'active'
             OR CLASS = 'link'

--- a/src/parser/constants.ts
+++ b/src/parser/constants.ts
@@ -1,4 +1,4 @@
-import { KeywordType } from '@/lexer/types';
+import { KeywordType, OperatorType, SymbolType } from '@/lexer/types';
 
 const keywordPriority: { [key: string]: number } = {
     [KeywordType.TAG]: 1,
@@ -7,6 +7,13 @@ const keywordPriority: { [key: string]: number } = {
     [KeywordType.CLASS]: 3,
     [KeywordType.ATTRIBUTE]: 5,
     [KeywordType.ATTR]: 5,
-};
+} as const;
 
-export { keywordPriority };
+const combinatorSeparators: { [key: string]: string } = {
+    [OperatorType.CHILD_OF]: SymbolType.GT,
+    [OperatorType.WITHIN]: ' ', // Whitespace
+    [OperatorType.NEXT_TO]: SymbolType.PLUS,
+    [OperatorType.SIBLING_OF]: SymbolType.TILDE,
+} as const;
+
+export { keywordPriority, combinatorSeparators };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -3,7 +3,7 @@ import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer
 import { keywordPriority } from './constants';
 import { buildExpressions } from './expressionBuilder';
 import { Expression, OperationType, QueryToken, Selector, SelectorGroup } from './types';
-import { getAttributeName, getSimpleOperationType, isValueToken } from './utilities';
+import { getAttributeName, getCombinatorSeparator, getSimpleOperationType, isCombinatorOperator, isValueToken } from './utilities';
 import { hasSecondaryOperator } from './validators';
 
 /**
@@ -42,7 +42,7 @@ function createSelectors(queryToken: QueryToken): SelectorGroup[] {
 /**
  * Groups selectors from multiple QueryTokens into a combined set of selector groups.
  * This function manages the merging of selectors based on their joining operators,
- * combining those joined by AND and separating those with other operators.
+ * combining those joined by `AND` or `combinator operators` and separating those with other operators.
  *
  * @param queryTokens - An array of QueryToken objects, each containing expressions and operators.
  * @returns An array of SelectorGroup objects, where each group represents a logical combination of selectors.
@@ -52,7 +52,7 @@ function groupSelectors(queryTokens: QueryToken[]): SelectorGroup[] {
 
     for (let i = 0; i < queryTokens.length; i++) {
         const queryGroupings = createSelectors(queryTokens[i]);
-        const lastGrouping = queryTokens[i].JoiningOperator === OperatorType.AND ? groupings.pop() : null;
+        const lastGrouping = queryTokens[i].JoiningOperator === OperatorType.AND || isCombinatorOperator(queryTokens[i].JoiningOperator) ? groupings.pop() : null;
 
         for (let j = 0; j < queryGroupings.length; j++) {
             groupings.push({
@@ -62,8 +62,21 @@ function groupSelectors(queryTokens: QueryToken[]): SelectorGroup[] {
     }
 
     for (let i = 0; i < groupings.length; i++) {
+        // Move combinator operators to the front of the group, but within 'OR' groupings
+        const combinatorSelectors = groupings[i].Selectors.filter(selector => isCombinatorOperator(selector.JoiningOperator)).reverse(); // Combinators next to each other should be in reverse order too
+        const otherSelectors = groupings[i].Selectors.filter(selector => !isCombinatorOperator(selector.JoiningOperator));
+
+        const orIdx = otherSelectors.findIndex(selector => selector.JoiningOperator === OperatorType.OR);
+
+        if (orIdx !== -1) {
+            groupings[i].Selectors = [...otherSelectors.slice(0, orIdx + 1), ...combinatorSelectors, ...otherSelectors.slice(orIdx + 1)];
+        } else {
+            groupings[i].Selectors = [...combinatorSelectors, ...otherSelectors];
+        }
+
+        // Now sort the non-combinator selectors within the group based on their keyword priority
         groupings[i].Selectors = groupings[i].Selectors.sort((a, b) => {
-            if (keywordPriority[a.KeywordType] && keywordPriority[b.KeywordType]) {
+            if (keywordPriority[a.KeywordType] && keywordPriority[b.KeywordType] && !isCombinatorOperator(a.JoiningOperator)) {
                 return keywordPriority[a.KeywordType] - keywordPriority[b.KeywordType];
             }
 
@@ -89,7 +102,7 @@ function generateQuery(groupings: SelectorGroup[]): string {
         let subQuery = '';
 
         for (let j = 0; j < groupings[i].Selectors.length; j++) {
-            subQuery += groupings[i].Selectors[j].Value;
+            subQuery += groupings[i].Selectors[j].Value + getCombinatorSeparator(groupings[i].Selectors[j].JoiningOperator);
         }
 
         query += i === 0 ? subQuery : `, ${subQuery}`;
@@ -114,7 +127,7 @@ function createSelector(expression: Expression): Selector {
     let secondaryOperator: Token | undefined;
 
     // Don't parse for comparator-less expressions. Ex. `...WHERE TAG('a')`
-    if (isValueToken(expression.nextToken()) == false) {
+    if (isValueToken(expression.nextToken()) == false && expression.nextToken()) {
         comparator = expression.consumeToken(TokenType.OPERATOR, [TokenType.IDENTIFIER, TokenType.SYMBOL]);
 
         if (expression.nextToken() && hasSecondaryOperator(comparator, expression.nextToken())) {
@@ -127,8 +140,12 @@ function createSelector(expression: Expression): Selector {
     let basicSelector = '';
 
     if (keyword.Value === KeywordType.TAG || keyword.Value === KeywordType.ELEMENT) {
-        const valueToken = expression.consumeToken(TokenType.STRING);
-        basicSelector = valueToken.Value;
+        if (keyword.Type === TokenType.FUNCTION) {
+            basicSelector = keyword.Arguments?.[0] ?? '';
+        } else {
+            const valueToken = expression.consumeToken(TokenType.STRING);
+            basicSelector = valueToken.Value;
+        }
     } else if (keyword.Value === KeywordType.ID) {
         const valueToken = expression.consumeToken(TokenType.STRING, [TokenType.NUMERIC]);
         basicSelector = getIdSelector(keyword, simpleComparatorType, valueToken);
@@ -142,7 +159,7 @@ function createSelector(expression: Expression): Selector {
             alternateTypes = [TokenType.NUMERIC];
         }
 
-        const valueToken = expression.consumeToken(TokenType.STRING, alternateTypes);
+        const valueToken = isValueToken(expression.nextToken()) ? expression.consumeToken(TokenType.STRING, alternateTypes) : undefined;
 
         basicSelector = getAttributeSelector(keyword, simpleComparatorType, valueToken);
     } else {
@@ -170,9 +187,19 @@ function createSelector(expression: Expression): Selector {
  * @param valueToken - The token containing the attribute or style value.
  * @returns A string representing the attribute selector in CSS format.
  */
-function getAttributeSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token): string {
-    if ((keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.ATTR) && keyword.Type !== TokenType.FUNCTION) {
-        return `[${valueToken.Value}]`;
+function getAttributeSelector(keyword: Token, simpleComparatorType: OperationType, valueToken: Token | undefined): string {
+    if (keyword.Value === KeywordType.ATTRIBUTE || keyword.Value === KeywordType.ATTR) {
+        if (keyword.Type !== TokenType.FUNCTION && valueToken) {
+            return `[${valueToken.Value}]`;
+        } else if (keyword.Type === TokenType.FUNCTION && !valueToken) {
+            return `[${keyword.Arguments?.[0] ?? ''}]`;
+        } else if (!valueToken) {
+            throw new Error(`Invalid attribute or style selector. Expected a value token, but none was provided.`);
+        }
+    }
+
+    if (!valueToken) {
+        throw new Error(`Invalid attribute or style selector. Expected a value token, but none was provided.`);
     }
 
     const attributeName = keyword.Type === TokenType.FUNCTION ? (keyword?.Arguments?.[0] ?? '') : getAttributeName(keyword);

--- a/src/parser/queryNotes.md
+++ b/src/parser/queryNotes.md
@@ -157,7 +157,7 @@ SELECT * FROM DOM WHERE
 
 ```sql
 SELECT * FROM DOM WHERE
-    TAG('div') CHILD OF TAG('p')
+    TAG('p') CHILD OF TAG('div')
 OR  (TAG = 'span' AND CLASS = 'text-blue')
 ```
 

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -46,7 +46,7 @@ class Expression {
     }
 }
 
-type JoiningOperatorType = OperatorType.AND | OperatorType.OR;
+type JoiningOperatorType = OperatorType.AND | OperatorType.OR | OperatorType.WITHIN | OperatorType.CHILD_OF | OperatorType.SIBLING_OF | OperatorType.NEXT_TO;
 
 interface CompoundExpression {
     Expressions: Expression[];

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -8,6 +8,12 @@ enum OperationType {
     NOT_CONTAINS = 'NOT_CONTAINS',
     LIKE = 'LIKE',
     NOT_LIKE = 'NOT_LIKE',
+
+    /* Combinators */
+    CHILD_OF = 'CHILD_OF',
+    SIBLING_OF = 'SIBLING_OF',
+    NEXT_TO = 'NEXT_TO',
+    WITHIN = 'WITHIN',
 }
 
 class Expression {

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -1,4 +1,4 @@
-import { KeywordType, OperatorType, SymbolType, Token } from '@/lexer/types';
+import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer/types';
 
 import { Expression, OperationType } from './types';
 
@@ -26,8 +26,16 @@ function getSimpleOperationType(value: string, secondaryValue: string | null): O
         return OperationType.NOT_LIKE;
     } else if (value === OperatorType.CONTAINS) {
         return OperationType.CONTAINS;
-    } else if (value === OperatorType.NOT && secondaryValue === OperationType.CONTAINS) {
+    } else if (value === OperatorType.NOT && secondaryValue === OperatorType.CONTAINS) {
         return OperationType.NOT_CONTAINS;
+    } else if (value === OperatorType.CHILD && secondaryValue === OperatorType.OF) {
+        return OperationType.CHILD_OF;
+    } else if (value === OperatorType.SIBLING && secondaryValue === OperatorType.OF) {
+        return OperationType.SIBLING_OF;
+    } else if (value === OperatorType.NEXT && secondaryValue === OperatorType.TO) {
+        return OperationType.NEXT_TO;
+    } else if (value === OperatorType.WITHIN) {
+        return OperationType.WITHIN;
     }
 
     return OperationType.UNKNOWN;
@@ -58,4 +66,12 @@ function deepCopy<T>(obj: T): T {
     return copy;
 }
 
-export { getAttributeName, getSimpleOperationType, deepCopy };
+function isValueToken(token: Token | null): boolean {
+    if (!token) {
+        return false;
+    }
+
+    return token.Type === TokenType.STRING || token.Type === TokenType.NUMERIC;
+}
+
+export { getAttributeName, getSimpleOperationType, deepCopy, isValueToken };

--- a/src/parser/utilities.ts
+++ b/src/parser/utilities.ts
@@ -1,6 +1,8 @@
+import { orOperatorSubstitutes } from '@/lexer/constants';
 import { KeywordType, OperatorType, SymbolType, Token, TokenType } from '@/lexer/types';
 
-import { Expression, OperationType } from './types';
+import { combinatorSeparators } from './constants';
+import { Expression, JoiningOperatorType, OperationType } from './types';
 
 function getAttributeName(token: Token): string {
     switch (token.Value) {
@@ -74,4 +76,54 @@ function isValueToken(token: Token | null): boolean {
     return token.Type === TokenType.STRING || token.Type === TokenType.NUMERIC;
 }
 
-export { getAttributeName, getSimpleOperationType, deepCopy, isValueToken };
+/**
+ * Determines if the token is an OR operator or a substitute for an OR operator.
+ *
+ * @param token - The token to be evaluated.
+ * @returns `true` if the token is an OR operator or a substitute for an OR operator, otherwise, `false`.
+ */
+function isOrSubstitute(token: Token | null): boolean {
+    if (!token) {
+        return false;
+    }
+
+    if (token.Value == OperatorType.OR) {
+        return true;
+    } else if (isCombinatorOperator(token.Value)) {
+        return true;
+    }
+
+    return false;
+}
+
+function isCombinatorOperator(joiningOperator: JoiningOperatorType | string | null | undefined): boolean {
+    if (!joiningOperator) {
+        return false;
+    }
+
+    return orOperatorSubstitutes.some(x => x == joiningOperator);
+}
+
+function getCombinatorSeparator(joiningOperator: JoiningOperatorType | null | undefined): string {
+    if (!joiningOperator) {
+        return '';
+    }
+
+    let selector = combinatorSeparators[joiningOperator];
+
+    if (!selector) {
+        return '';
+    }
+
+    if (!selector.startsWith(' ')) {
+        selector = ` ${selector}`;
+    }
+
+    if (!selector.endsWith(' ')) {
+        selector += ' ';
+    }
+
+    return selector;
+}
+
+export { getAttributeName, getSimpleOperationType, deepCopy, isValueToken, isCombinatorOperator, isOrSubstitute, getCombinatorSeparator };

--- a/src/parser/validators.ts
+++ b/src/parser/validators.ts
@@ -1,6 +1,6 @@
 import { OperatorType, Token } from '@/lexer/types';
 
-function hasSecondaryOperator(operator: Token, nextToken: Token | null): Boolean {
+function hasSecondaryOperator(operator: Token, nextToken: Token | null): boolean {
     if (nextToken == null) return false;
 
     if (operator.Value === OperatorType.NOT) {


### PR DESCRIPTION
- Added support for combinators ` `, `>`, `+`, `~`

Ex. `div > div > p`
``` sql
SELECT * ...
TAG('p') CHILD OF TAG('div') AND CHILD OF TAG('div')
```
- Resolving function calls that use no value token erroring out (tags/elements & attributes)