### PR TITLE
bug: Resolving OR operator not creating parenthesis when next to comb…

### DIFF
--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -95,7 +95,7 @@ function lexer(input: string): Token[] {
         let operatorFound = false;
 
         for (const key in operators) {
-            if (rawToken.startsWith(key + ' ')) {
+            if (rawToken.toUpperCase().startsWith(key + ' ')) {
                 // Must have a space after it. Otherwise `<` can parse on a `<>`. *Should actually do a forward seek instead... or largest match wins?.
                 tokens.push({ Type: operators[key], Value: key });
 

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -154,9 +154,7 @@ import { parser } from './parser';
     AND Attribute('data-color') = 'red'
  */
 
-const sqlDomQuery = `SELECT * FROM DOM WHERE
-TAG('p') WITHIN TAG('div')
-`;
+const sqlDomQuery = `SELECT * FROM DOM WHERE TAG = 'a' child of TAG = 'div' OR TAG = 'body' child of TAG <> 'a'`;
 
 const lexerTokens = lexer(sqlDomQuery);
 console.log('Lexer Tokens: ', lexerTokens);

--- a/src/parser/expressionBuilder.ts
+++ b/src/parser/expressionBuilder.ts
@@ -122,7 +122,7 @@ function buildExpressions(tokens: Token[]): QueryToken[] {
                 if (expression) {
                     if (compoundExpression) {
                         /* Artificial Braces/Compound - Close off the compound */
-                        if (isArtificialCompound && (isOrSubstitute(token) || _tokens[0].Value == SymbolType.LPAREN)) {
+                        if (isArtificialCompound && (token.Value == OperatorType.OR || _tokens[0].Value == SymbolType.LPAREN)) {
                             if (isOrSubstitute(token)) {
                                 if (_tokens[0].Value != SymbolType.LPAREN) {
                                     // Artificially add brace for next compound query


### PR DESCRIPTION
…inator in `expressionBuilder.ts`

bug: Operators during tokenization, now properly ignores casing
test: Adding combinator tests for `TAG` & `ELEMENT` on `EQUAL` operations