### PR TITLE
feat: Adding support for `of-type` structural pseudo selectors using …

### DIFF
--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -6,6 +6,7 @@ const keywords: { [key: string]: TokenType } = {
     [KeywordType.SELECT]: TokenType.KEYWORD,
     [KeywordType.FROM]: TokenType.KEYWORD,
     [KeywordType.WHERE]: TokenType.KEYWORD,
+    [KeywordType.AS]: TokenType.KEYWORD,
 
     [KeywordType.TAG]: TokenType.KEYWORD,
     [KeywordType.ELEMENT]: TokenType.KEYWORD,
@@ -55,6 +56,10 @@ const functions: { [key: string]: TokenType } = {
     [FunctionType.CHILD]: TokenType.FUNCTION,
 };
 
+const standaloneFunctions: { [key: string]: TokenType } = {
+    [FunctionType.TYPEOF]: TokenType.FUNCTION,
+};
+
 const tokenSequenceReplaceables: { [key: string]: OperatorType[] } = {
     [OperatorType.CHILD_OF]: [OperatorType.CHILD, OperatorType.OF],
     [OperatorType.NEXT_TO]: [OperatorType.NEXT, OperatorType.TO],
@@ -76,4 +81,4 @@ const Regex = {
     expression: /^[+-]?\s*\d*\s*N\s*(?:[+-]\s*\d+)?$|^[+-]?\s*\d+$|^\s*n\s*/,
 };
 
-export { Regex, keywords, operators, functions, tokenSequenceReplaceables, orOperatorSubstitutes };
+export { Regex, keywords, operators, functions, standaloneFunctions, tokenSequenceReplaceables, orOperatorSubstitutes };

--- a/src/lexer/index.ts
+++ b/src/lexer/index.ts
@@ -1,4 +1,4 @@
-import { functions, keywords, operators, Regex, tokenSequenceReplaceables } from './constants';
+import { functions, keywords, operators, Regex, standaloneFunctions, tokenSequenceReplaceables } from './constants';
 import { SymbolType, Token, TokenType } from './types';
 
 function cleanToken(value: string): string {
@@ -124,6 +124,8 @@ function lexer(input: string): Token[] {
 
             if (keywords[matchValue] == TokenType.KEYWORD) {
                 tokenType = TokenType.KEYWORD;
+            } else if (standaloneFunctions[matchValue]) {
+                tokenType = TokenType.FUNCTION;
             }
 
             tokens.push({ Type: tokenType, Value: matchValue.trim() });

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -19,6 +19,7 @@ enum KeywordType {
     SELECT = 'SELECT',
     FROM = 'FROM',
     WHERE = 'WHERE',
+    AS = 'AS',
 
     TAG = 'TAG', // TAG == ELEMENT
     ELEMENT = 'ELEMENT', // ELEMENT == TAG

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -154,7 +154,7 @@ import { parser } from './parser';
     AND Attribute('data-color') = 'red'
  */
 
-const sqlDomQuery = `SELECT * FROM DOM WHERE ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a' AND CHILD(ODD, - 2N + 2)`;
+const sqlDomQuery = `SELECT * FROM DOM WHERE ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a' AND CHILD() AS TYPEOF`;
 
 const lexerTokens = lexer(sqlDomQuery);
 console.log('Lexer Tokens: ', lexerTokens);

--- a/src/parser/types.ts
+++ b/src/parser/types.ts
@@ -19,6 +19,7 @@ enum OperationType {
 class Expression {
     Tokens: Token[];
     JoiningOperator: JoiningOperatorType;
+    #previousToken: Token | undefined;
 
     constructor(tokens: Token[], joiningOperator: JoiningOperatorType) {
         this.Tokens = tokens;
@@ -38,11 +39,22 @@ class Expression {
             }
         }
 
+        this.#previousToken = token;
+
         return token;
     }
 
     nextToken(): Token | null {
         return this.Tokens.length > 0 ? this.Tokens[0] : null;
+    }
+
+    revertToken(): Token | null {
+        if (!this.#previousToken) return null;
+
+        this.Tokens.unshift(this.#previousToken);
+        this.#previousToken = undefined;
+
+        return this.Tokens[0];
     }
 }
 

--- a/src/parser/validators.ts
+++ b/src/parser/validators.ts
@@ -1,4 +1,4 @@
-import { OperatorType, Token } from '@/lexer/types';
+import { FunctionType, OperatorType, Token, TokenType } from '@/lexer/types';
 
 function hasSecondaryOperator(operator: Token, nextToken: Token | null): boolean {
     if (nextToken == null) return false;
@@ -17,4 +17,12 @@ function hasSecondaryOperator(operator: Token, nextToken: Token | null): boolean
     return false;
 }
 
-export { hasSecondaryOperator };
+function isPseudoSelector(token: Token): boolean {
+    if (token.Value === FunctionType.CHILD && token.Type === TokenType.FUNCTION) {
+        return true;
+    }
+
+    return false;
+}
+
+export { hasSecondaryOperator, isPseudoSelector };


### PR DESCRIPTION
…the `TYPEOF` function

bug: Resolving empty argument list that should be treated as `CHILD(FIRST)`, but throws error instead
feat: Parsing of function types without braces inside lexer tokenizer