### PR TITLE
Feature/pseudo selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,10 @@ Please see [Local Development](#Local-Development) for working with the source.
 - ~~Resolve selectors duplicating with multiple un-grouped `OR` operators~~
 - ~~Implement combinators, ex. ` `, `>`, `+`, `~`~~
 - Add support for nested groupings of `(...)`
-- (***Active***) Implement pseudo selectors
-- Improve type checking & syntax errors
+- ~~Implement pseudo selectors~~
+- (***Next***) Improve type checking & syntax errors
 - ~~Unit testing~~
-- (***Next***) Comments with `--`
+- (***Active***) Comments with `--`
 - Support escaping characters?
 
 ## Local Development

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -23,6 +23,7 @@ const keywords: { [key: string]: TokenType } = {
     [KeywordType.EVEN]: TokenType.KEYWORD,
     [KeywordType.ONLY]: TokenType.KEYWORD,
     [KeywordType.EMPTY]: TokenType.KEYWORD,
+    [KeywordType.ROOT]: TokenType.KEYWORD,
 
     /* Pseudo Selectors - Link */
     [KeywordType.LINK]: TokenType.KEYWORD,

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -76,6 +76,8 @@ const functions: { [key: string]: TokenType } = {
     [FunctionType.TAG]: TokenType.FUNCTION,
     [FunctionType.CHILD]: TokenType.FUNCTION,
     [FunctionType.TYPEOF]: TokenType.FUNCTION,
+    [FunctionType.LANGUAGE]: TokenType.FUNCTION,
+    [FunctionType.LANG]: TokenType.FUNCTION,
 };
 
 const standaloneFunctions: { [key: string]: TokenType } = {

--- a/src/lexer/constants.ts
+++ b/src/lexer/constants.ts
@@ -16,13 +16,34 @@ const keywords: { [key: string]: TokenType } = {
     [KeywordType.ATTR]: TokenType.KEYWORD,
     [KeywordType.STYLE]: TokenType.KEYWORD,
 
-    /* Pseudo Selectors */
+    /* Pseudo Selectors - Structural */
     [KeywordType.FIRST]: TokenType.KEYWORD,
     [KeywordType.LAST]: TokenType.KEYWORD,
     [KeywordType.ODD]: TokenType.KEYWORD,
     [KeywordType.EVEN]: TokenType.KEYWORD,
     [KeywordType.ONLY]: TokenType.KEYWORD,
     [KeywordType.EMPTY]: TokenType.KEYWORD,
+
+    /* Pseudo Selectors - Link */
+    [KeywordType.LINK]: TokenType.KEYWORD,
+    [KeywordType.VISITED]: TokenType.KEYWORD,
+
+    /* Pseudo Selectors - User Action */
+    [KeywordType.ACTIVE]: TokenType.KEYWORD,
+    [KeywordType.HOVER]: TokenType.KEYWORD,
+    [KeywordType.FOCUS]: TokenType.KEYWORD,
+
+    /* Pseudo Selectors - UI Element */
+    [KeywordType.ENABLED]: TokenType.KEYWORD,
+    [KeywordType.DISABLED]: TokenType.KEYWORD,
+    [KeywordType.CHECKED]: TokenType.KEYWORD,
+
+    /* Pseudo Selectors - Misc */
+    [KeywordType.FIRSTLINE]: TokenType.KEYWORD,
+    [KeywordType.FIRSTLETTER]: TokenType.KEYWORD,
+    [KeywordType.TARGET]: TokenType.KEYWORD,
+    [KeywordType.BEFORE]: TokenType.KEYWORD,
+    [KeywordType.AFTER]: TokenType.KEYWORD,
 } as const;
 
 const operators: { [key: string]: TokenType } = {
@@ -54,6 +75,7 @@ const functions: { [key: string]: TokenType } = {
     [FunctionType.ATTR]: TokenType.FUNCTION,
     [FunctionType.TAG]: TokenType.FUNCTION,
     [FunctionType.CHILD]: TokenType.FUNCTION,
+    [FunctionType.TYPEOF]: TokenType.FUNCTION,
 };
 
 const standaloneFunctions: { [key: string]: TokenType } = {

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -36,6 +36,7 @@ enum KeywordType {
     EVEN = 'EVEN',
     ONLY = 'ONLY',
     EMPTY = 'EMPTY',
+    ROOT = 'ROOT',
 
     /* Pseudo Selectors - Link */
     LINK = 'LINK',

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -29,13 +29,34 @@ enum KeywordType {
     ATTR = 'ATTR', // ATR == ATTRIBUTE
     STYLE = 'STYLE',
 
-    /* Pseudo Selectors */
+    /* Pseudo Selectors - Structural */
     FIRST = 'FIRST',
     LAST = 'LAST',
     ODD = 'ODD',
     EVEN = 'EVEN',
     ONLY = 'ONLY',
     EMPTY = 'EMPTY',
+
+    /* Pseudo Selectors - Link */
+    LINK = 'LINK',
+    VISITED = 'VISITED',
+
+    /* Pseudo Selectors - User Action */
+    ACTIVE = 'ACTIVE',
+    HOVER = 'HOVER',
+    FOCUS = 'FOCUS',
+
+    /* Pseudo Selectors - UI Element */
+    ENABLED = 'ENABLED',
+    DISABLED = 'DISABLED',
+    CHECKED = 'CHECKED',
+
+    /* Pseudo Selectors - Misc */
+    FIRSTLINE = 'FIRSTLINE',
+    FIRSTLETTER = 'FIRSTLETTER',
+    TARGET = 'TARGET',
+    BEFORE = 'BEFORE',
+    AFTER = 'AFTER',
 }
 
 enum OperatorType {

--- a/src/lexer/types.ts
+++ b/src/lexer/types.ts
@@ -85,6 +85,8 @@ enum FunctionType {
     TAG = 'TAG',
     CHILD = 'CHILD',
     TYPEOF = 'TYPEOF', // Equal representation for the `of-type` in structural pseudo selectors
+    LANGUAGE = 'LANGUAGE', // LANGUAGE == LANG
+    LANG = 'LANG', // LANG == LANGUAGE
 }
 
 enum CompoundType {

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -154,7 +154,7 @@ import { parser } from './parser';
     AND Attribute('data-color') = 'red'
  */
 
-const sqlDomQuery = `SELECT * FROM DOM WHERE ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a' AND CHILD() AS TYPEOF`;
+const sqlDomQuery = `SELECT * FROM DOM WHERE ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a' AND CHILD() AS TYPEOF AND TYPEOF(FIRSTLETTER)`;
 
 const lexerTokens = lexer(sqlDomQuery);
 console.log('Lexer Tokens: ', lexerTokens);

--- a/src/localTesting.ts
+++ b/src/localTesting.ts
@@ -154,7 +154,7 @@ import { parser } from './parser';
     AND Attribute('data-color') = 'red'
  */
 
-const sqlDomQuery = `SELECT * FROM DOM WHERE ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a' AND CHILD() AS TYPEOF AND TYPEOF(FIRSTLETTER)`;
+const sqlDomQuery = `SELECT * FROM DOM WHERE ATTR('value') = 'ready' AND CLASS = 'btn-blue' AND ID = 'confirm-link' AND TAG = 'a' AND CHILD() AS TYPEOF AND TYPEOF(FIRSTLETTER) WITHIN LANGUAGE('fr')`;
 
 const lexerTokens = lexer(sqlDomQuery);
 console.log('Lexer Tokens: ', lexerTokens);

--- a/src/parser/constants.ts
+++ b/src/parser/constants.ts
@@ -16,4 +16,20 @@ const combinatorSeparators: { [key: string]: string } = {
     [OperatorType.SIBLING_OF]: SymbolType.TILDE,
 } as const;
 
-export { keywordPriority, combinatorSeparators };
+const pseudoKeywordSelector: { [key: string]: string } = {
+    [KeywordType.LINK]: 'link',
+    [KeywordType.VISITED]: 'visited',
+    [KeywordType.ACTIVE]: 'active',
+    [KeywordType.HOVER]: 'hover',
+    [KeywordType.FOCUS]: 'focus',
+    [KeywordType.ENABLED]: 'enabled',
+    [KeywordType.DISABLED]: 'disabled',
+    [KeywordType.CHECKED]: 'checked',
+    [KeywordType.FIRSTLINE]: 'first-line',
+    [KeywordType.FIRSTLETTER]: 'first-letter',
+    [KeywordType.TARGET]: 'target',
+    [KeywordType.BEFORE]: 'before',
+    [KeywordType.AFTER]: 'after',
+} as const;
+
+export { keywordPriority, combinatorSeparators, pseudoKeywordSelector };

--- a/src/parser/index.ts
+++ b/src/parser/index.ts
@@ -347,6 +347,8 @@ function getStructuralPseudoSelector($function: Token, operationFunction: Token 
             selector = `only-${pseudoSelectorFunction}`;
         } else if (argument_1.Value === KeywordType.EMPTY) {
             selector = 'empty';
+        } else if (argument_1.Value === KeywordType.ROOT) {
+            selector = 'root';
         }
     } else if (argument_1?.Type === TokenType.EXPRESSION || argument_1?.Type === TokenType.NUMERIC) {
         nthExpression = argument_1.Value;


### PR DESCRIPTION
- feat: Adding support for basic pseudo selectors (link, target, UI element & misc)
- feat: Adding support for the language pseudo selector `:lang()`
- bug: Resolving generic pseudo selector not appending a extra `:` for some selectors
- docs: Appending comments for new pseudo functions
- feat: adding support for the ROOT structural pseudo selector